### PR TITLE
Memory-x generation

### DIFF
--- a/data/parts.yaml
+++ b/data/parts.yaml
@@ -17,15 +17,25 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz753
   part_numbers:
   - name: msps003f3 # Part number
-    flash: 8 # KB
-    ram: 1 # KB
+    memory:
+    - name: FLASH
+      length: 8 # KB
+      address: 0x00000000
+    - name: SRAM
+      length: 1 # KB
+      address: 0x20000000
     # Package codes
     packages:
     - PW20
 
   - name: msps003f4
-    flash: 16
-    ram: 1
+    memory:
+    - name: FLASH
+      length: 16
+      address: 0x00000000
+    - name: SRAM
+      length: 1
+      address: 0x20000000
     packages:
     - PW20
 
@@ -35,8 +45,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz753
   part_numbers:
   - name: mspm0c1103
-    flash: 8
-    ram: 1
+    memory:
+    - name: FLASH
+      length: 8
+      address: 0x00000000
+    - name: SRAM
+      length: 1
+      address: 0x20000000
     packages:
     - DGS20
     - DSG
@@ -44,8 +59,13 @@ families:
     - RUK
 
   - name: mspm0c1104
-    flash: 16
-    ram: 1
+    memory:
+    - name: FLASH
+      length: 16
+      address: 0x00000000
+    - name: SRAM
+      length: 1
+      address: 0x20000000
     packages:
     - DGS20'
     - DSG
@@ -60,8 +80,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz742
   part_numbers:
   - name: mspm0g1105
-    flash: 32
-    ram: 16
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 16
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -71,8 +96,13 @@ families:
     - RHB
   
   - name: mspm0g1106
-    flash: 64
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -82,8 +112,13 @@ families:
     - RHB
   
   - name: mspm0g1107
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 128
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -99,8 +134,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz742
   part_numbers:
   - name: mspm0g1505
-    flash: 32
-    ram: 16
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 16
+      address: 0x20200000
     packages:
     - DGS
     - PM
@@ -110,8 +150,13 @@ families:
     - RHB
 
   - name: mspm0g1506
-    flash: 64
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS
     - PM
@@ -121,8 +166,13 @@ families:
     - RHB
 
   - name: mspm0g1507
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS
     - PM
@@ -138,16 +188,32 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz758
   part_numbers:
   - name: mspm0g1518
-    flash: 256
-    ram: 128
+    memory:
+    - name: FLASH
+      length: 256
+      address: 0x00000000
+    - name: SRAM_BANK0
+      length: 64
+      address: 0x20200000
+    - name: SRAM_BANK1
+      length: 64
+      address: 0x20210000
     # SLASFA2 (November 2024) states that G1518 has no orderable parts
     #
     # This will likely change in the future as the chip is "prerelease"
     packages:
 
   - name: mspm0g1519
-    flash: 512
-    ram: 128
+    memory:
+    - name: FLASH
+      length: 512
+      address: 0x00000000
+    - name: SRAM_BANK0
+      length: 64
+      address: 0x20200000
+    - name: SRAM_BANK1
+      length: 64
+      address: 0x20210000
     # TODO: SLASFA2 does not list all packages yet
     packages:
     - RGZ
@@ -159,24 +225,39 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz742
   part_numbers:
   - name: mspm0g3105
-    flash: 32
-    ram: 16
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 16
+      address: 0x20200000
     packages:
     - DGS20
     - DGS28
     - RHB
 
   - name: mspm0g3106
-    flash: 64
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS20
     - DGS28
     - RHB
 
   - name: mspm0g3107
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 128
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS20
     - DGS28
@@ -188,8 +269,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz742
   part_numbers:
   - name: mspm0g3505
-    flash: 32
-    ram: 16
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 16
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -198,8 +284,13 @@ families:
     - RHB
 
   - name: mspm0g3506
-    flash: 64
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -208,8 +299,13 @@ families:
     - RHB
 
   - name: mspm0g3507
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 128
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - DGS28
     - PM
@@ -223,16 +319,32 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz758
   part_numbers:
   - name: mspm0g3518
-    flash: 256
-    ram: 128
+    memory:
+    - name: FLASH
+      length: 256
+      address: 0x00000000
+    - name: SRAM_BANK0
+      length: 64
+      address: 0x20200000
+    - name: SRAM_BANK1
+      length: 64
+      address: 0x20210000
     # SLASFA2 (November 2024) states that G1518 has no orderable parts
     #
     # This will likely change in the future as the chip is "prerelease"
     packages:
 
   - name: mspm0g3519
-    flash: 512
-    ram: 128
+    memory:
+    - name: FLASH
+      length: 512
+      address: 0x00000000
+    - name: SRAM_BANK0
+      length: 64
+      address: 0x20200000
+    - name: SRAM_BANK1
+      length: 64
+      address: 0x20210000
     # TODO: SLASFA2 does not list all packages yet
     packages:
     - PM
@@ -248,8 +360,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz741
   part_numbers:
   - name: mspm0l1105
-    flash: 32
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS20
     - DGS28
@@ -259,8 +376,13 @@ families:
     - RTR
 
   - name: mspm0l1106
-    flash: 64
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS20
     - DGS28
@@ -275,8 +397,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz755
   part_numbers:
   - name: mspm0l1227
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 128
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - PM
     - PN
@@ -286,8 +413,13 @@ families:
     - RHB
 
   - name: mspm0l1228
-    flash: 256
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 256
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - PM
     - PN
@@ -302,14 +434,24 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz741
   part_numbers:
   - name: mspm0l1303
-    flash: 8
-    ram: 2
+    memory:
+    - name: FLASH
+      length: 8
+      address: 0x00000000
+    - name: SRAM
+      length: 2
+      address: 0x20000000
     packages:
     - RGE
 
   - name: mspm0l1304
-    flash: 16
-    ram: 2
+    memory:
+    - name: FLASH
+      length: 16
+      address: 0x00000000
+    - name: SRAM
+      length: 2
+      address: 0x20000000
     packages:
     - DGS20
     - DGS28
@@ -319,8 +461,13 @@ families:
     - RTR
 
   - name: mspm0l1305
-    flash: 32
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS20
     - DGS28
@@ -330,8 +477,13 @@ families:
     - RTR
 
   - name: mspm0l1306
-    flash: 64
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS20
     - DGS28
@@ -345,26 +497,46 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz741
   part_numbers:
   - name: mspm0l1343
-    flash: 8
-    ram: 2
+    memory:
+    - name: FLASH
+      length: 8
+      address: 0x00000000
+    - name: SRAM
+      length: 2
+      address: 0x20000000
     packages:
     - DGS20
 
   - name: mspm0l1344
-    flash: 16
-    ram: 2
+    memory:
+    - name: FLASH
+      length: 16
+      address: 0x00000000
+    - name: SRAM
+      length: 2
+      address: 0x20000000
     packages:
     - DGS20
 
   - name: mspm0l1345
-    flash: 32
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 32
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS28
 
   - name: mspm0l1346
-    flash: 64
-    ram: 4
+    memory:
+    - name: FLASH
+      length: 64
+      address: 0x00000000
+    - name: SRAM
+      length: 4
+      address: 0x20000000
     packages:
     - DGS28
 
@@ -374,8 +546,13 @@ families:
   errata_url: https://www.ti.com/lit/pdf/slaz755
   part_numbers:
   - name: mspm0l2227
-    flash: 128
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 128
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - PM
     - PN
@@ -383,8 +560,13 @@ families:
     - RGZ
 
   - name: mspm0l2228
-    flash: 256
-    ram: 32
+    memory:
+    - name: FLASH
+      length: 256
+      address: 0x00000000
+    - name: SRAM
+      length: 32
+      address: 0x20200000
     packages:
     - PM
     - PN

--- a/data/parts.yaml
+++ b/data/parts.yaml
@@ -21,7 +21,7 @@ families:
     - name: FLASH
       length: 8 # KB
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 1 # KB
       address: 0x20000000
     # Package codes
@@ -33,7 +33,7 @@ families:
     - name: FLASH
       length: 16
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 1
       address: 0x20000000
     packages:
@@ -49,7 +49,7 @@ families:
     - name: FLASH
       length: 8
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 1
       address: 0x20000000
     packages:
@@ -63,7 +63,7 @@ families:
     - name: FLASH
       length: 16
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 1
       address: 0x20000000
     packages:
@@ -84,7 +84,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 16
       address: 0x20200000
     packages:
@@ -100,7 +100,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -116,7 +116,7 @@ families:
     - name: FLASH
       length: 128
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -138,7 +138,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 16
       address: 0x20200000
     packages:
@@ -154,7 +154,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -170,7 +170,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -192,10 +192,15 @@ families:
     - name: FLASH
       length: 256
       address: 0x00000000
-    - name: SRAM_BANK0
+      # Note: RAM on this device is continuous memory but partitioned in the
+      # linker into two separate sections. This is to account for the upper 64kB
+      # of RAM being wiped out upon the device entering any low-power mode
+      # stronger than SLEEP. Thus, it is up to the end-user to enable RAM_BANK for
+      # applications where the memory is considered lost outside of RUN and SLEEP Modes.
+    - name: RAM
       length: 64
       address: 0x20200000
-    - name: SRAM_BANK1
+    - name: RAM_BANK
       length: 64
       address: 0x20210000
     # SLASFA2 (November 2024) states that G1518 has no orderable parts
@@ -208,10 +213,15 @@ families:
     - name: FLASH
       length: 512
       address: 0x00000000
-    - name: SRAM_BANK0
+      # Note: RAM on this device is continuous memory but partitioned in the
+      # linker into two separate sections. This is to account for the upper 64kB
+      # of RAM being wiped out upon the device entering any low-power mode
+      # stronger than SLEEP. Thus, it is up to the end-user to enable RAM_BANK for
+      # applications where the memory is considered lost outside of RUN and SLEEP Modes.
+    - name: RAM
       length: 64
       address: 0x20200000
-    - name: SRAM_BANK1
+    - name: RAM_BANK
       length: 64
       address: 0x20210000
     # TODO: SLASFA2 does not list all packages yet
@@ -229,7 +239,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 16
       address: 0x20200000
     packages:
@@ -242,7 +252,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -255,7 +265,7 @@ families:
     - name: FLASH
       length: 128
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -273,7 +283,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 16
       address: 0x20200000
     packages:
@@ -288,7 +298,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -303,7 +313,7 @@ families:
     - name: FLASH
       length: 128
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -323,10 +333,15 @@ families:
     - name: FLASH
       length: 256
       address: 0x00000000
-    - name: SRAM_BANK0
+      # Note: RAM on this device is continuous memory but partitioned in the
+      # linker into two separate sections. This is to account for the upper 64kB
+      # of RAM being wiped out upon the device entering any low-power mode
+      # stronger than SLEEP. Thus, it is up to the end-user to enable RAM_BANK for
+      # applications where the memory is considered lost outside of RUN and SLEEP Modes.
+    - name: RAM
       length: 64
       address: 0x20200000
-    - name: SRAM_BANK1
+    - name: RAM_BANK
       length: 64
       address: 0x20210000
     # SLASFA2 (November 2024) states that G1518 has no orderable parts
@@ -339,10 +354,15 @@ families:
     - name: FLASH
       length: 512
       address: 0x00000000
-    - name: SRAM_BANK0
+      # Note: RAM on this device is continuous memory but partitioned in the
+      # linker into two separate sections. This is to account for the upper 64kB
+      # of RAM being wiped out upon the device entering any low-power mode
+      # stronger than SLEEP. Thus, it is up to the end-user to enable RAM_BANK for
+      # applications where the memory is considered lost outside of RUN and SLEEP Modes.
+    - name: RAM
       length: 64
       address: 0x20200000
-    - name: SRAM_BANK1
+    - name: RAM_BANK
       length: 64
       address: 0x20210000
     # TODO: SLASFA2 does not list all packages yet
@@ -364,7 +384,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -380,7 +400,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -401,7 +421,7 @@ families:
     - name: FLASH
       length: 128
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -417,7 +437,7 @@ families:
     - name: FLASH
       length: 256
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -438,7 +458,7 @@ families:
     - name: FLASH
       length: 8
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 2
       address: 0x20000000
     packages:
@@ -449,7 +469,7 @@ families:
     - name: FLASH
       length: 16
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 2
       address: 0x20000000
     packages:
@@ -465,7 +485,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -481,7 +501,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -501,7 +521,7 @@ families:
     - name: FLASH
       length: 8
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 2
       address: 0x20000000
     packages:
@@ -512,7 +532,7 @@ families:
     - name: FLASH
       length: 16
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 2
       address: 0x20000000
     packages:
@@ -523,7 +543,7 @@ families:
     - name: FLASH
       length: 32
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -534,7 +554,7 @@ families:
     - name: FLASH
       length: 64
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 4
       address: 0x20000000
     packages:
@@ -550,7 +570,7 @@ families:
     - name: FLASH
       length: 128
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:
@@ -564,7 +584,7 @@ families:
     - name: FLASH
       length: 256
       address: 0x00000000
-    - name: SRAM
+    - name: RAM
       length: 32
       address: 0x20200000
     packages:

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -2,15 +2,15 @@ use std::{borrow::Cow, cmp::Ordering, collections::BTreeMap, fs, sync::LazyLock}
 
 use anyhow::{bail, Context};
 use mspm0_data_types::{
-    Chip, DmaChannel, Interrupt, Package, PackagePin, Peripheral, PeripheralPin, PeripheralType,
-    PowerDomain,
+    Chip, DmaChannel, Interrupt, Memory, Package, PackagePin, Peripheral, PeripheralPin,
+    PeripheralType, PowerDomain,
 };
 use regex::Regex;
 
 use crate::{
     header::{Header, Headers},
     int_group::Groups,
-    parts::{PartFamily, PartsFile},
+    parts::{PartFamily, PartMemory, PartsFile},
     sysconfig::{self, PartPeripheralWrapper, Sysconfig, SysconfigFile},
     verify,
 };
@@ -77,8 +77,7 @@ fn generate_family(
             datasheet_url: family.datasheet_url.clone(),
             reference_manual_url: family.reference_manual_url.clone(),
             errata_url: family.errata_url.clone(),
-            ram: part_number.ram,
-            flash: part_number.flash,
+            memory: part_number.memory.iter().map(convert_memory).collect(),
             packages: packages.collect(),
             iomux: iomux.clone(),
             peripherals: peripherals.clone(),
@@ -723,4 +722,12 @@ fn skip_peripheral_pin(pin_name: &String, chip_name: &str) -> bool {
     }
 
     false
+}
+
+fn convert_memory(memory: &PartMemory) -> Memory {
+    Memory {
+        name: memory.name.clone(),
+        length: memory.length,
+        address: memory.address,
+    }
 }

--- a/mspm0-data-gen/src/parts.rs
+++ b/mspm0-data-gen/src/parts.rs
@@ -39,12 +39,21 @@ pub struct PartNumber {
     /// The part number.
     pub name: String,
 
-    /// Amount of flash in KB.
-    pub flash: u32,
-
-    /// Amount of ram in KB.
-    pub ram: u32,
+    /// Memory layout.
+    pub memory: Vec<PartMemory>,
 
     /// The packages available for this part number.
     pub packages: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PartMemory {
+    /// The memory partition.
+    pub name: String,
+
+    /// Amount of memory in KB.
+    pub length: u32,
+
+    /// Address of the memory.
+    pub address: u32,
 }

--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -22,11 +22,8 @@ pub struct Chip {
     /// URL for the errata.
     pub errata_url: String,
 
-    /// Amount of ram in KB.
-    pub ram: u32,
-
-    /// Amount of flash in KB.
-    pub flash: u32,
+    /// Memory layout.
+    pub memory: Vec<Memory>,
 
     /// Packages which this chip is available in.
     pub packages: Vec<Package>,
@@ -253,4 +250,16 @@ pub struct Interrupt {
 pub struct DmaChannel {
     /// Whether this is a full channel or basic channel.
     pub full: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Memory {
+    /// The memory partition.
+    pub name: String,
+
+    /// Amount of memory in KB.
+    pub length: u32,
+
+    /// Address of the memory.
+    pub address: u32,
 }

--- a/mspm0-metapac-gen/res/build.rs
+++ b/mspm0-metapac-gen/res/build.rs
@@ -41,16 +41,9 @@ fn main() {
     .to_ascii_lowercase()
     .replace('_', "-");
 
-    #[cfg(feature = "rt")]
+    #[cfg(any(feature = "rt", feature = "memory-x"))]
     println!(
         "cargo:rustc-link-search={}/src/chips/{}",
-        crate_dir.display(),
-        chip_name,
-    );
-
-    #[cfg(feature = "memory-x")]
-    println!(
-        "cargo:rustc-link-search={}/src/chips/{}/memory_x/",
         crate_dir.display(),
         chip_name,
     );

--- a/mspm0-metapac-gen/src/linker.rs
+++ b/mspm0-metapac-gen/src/linker.rs
@@ -24,3 +24,25 @@ pub fn generate_device_x(name: &str, chip: &Chip, out_dir: &Path) -> anyhow::Res
     drop(file);
     Ok(())
 }
+
+pub fn generate_memory_x(name: &str, chip: &Chip, out_dir: &Path) -> anyhow::Result<()> {
+    let dir = out_dir.join("src/chips").join(&name);
+    fs::create_dir_all(&dir)?;
+
+    let path = dir.join("memory.x");
+    let mut file = File::create(&path)?;
+
+    write!(file, "MEMORY\n{{\n").unwrap();
+    for memory in chip.memory.iter() {
+        writeln!(
+            file,
+            "    {} : ORIGIN = 0x{:08x}, LENGTH = {}K",
+            memory.name, memory.address, memory.length,
+        )
+        .unwrap();
+    }
+    write!(file, "}}").unwrap();
+
+    drop(file);
+    Ok(())
+}

--- a/mspm0-metapac-gen/src/linker.rs
+++ b/mspm0-metapac-gen/src/linker.rs
@@ -34,6 +34,18 @@ pub fn generate_memory_x(name: &str, chip: &Chip, out_dir: &Path) -> anyhow::Res
 
     write!(file, "MEMORY\n{{\n").unwrap();
     for memory in chip.memory.iter() {
+        if memory.name.contains("RAM_BANK") {
+            write!(
+                file,
+                "    # Note: RAM on this device is continuous memory but partitioned in the
+    # linker into two separate sections. This is to account for the upper 64kB
+    # of RAM being wiped out upon the device entering any low-power mode
+    # stronger than SLEEP. Thus, it is up to the end-user to enable RAM_BANK for
+    # applications where the memory is considered lost outside of RUN and SLEEP Modes.
+"
+            )
+            .unwrap();
+        }
         writeln!(
             file,
             "    {} : ORIGIN = 0x{:08x}, LENGTH = {}K",

--- a/mspm0-metapac-gen/src/main.rs
+++ b/mspm0-metapac-gen/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> anyhow::Result<()> {
         generate_chip_pac(name, chip, &out_dir);
         generate_chip_metadata(name, chip, &out_dir);
         linker::generate_device_x(name, chip, &out_dir)?;
+        linker::generate_memory_x(name, chip, &out_dir)?;
 
         // TODO: Generate memory.x
     }


### PR DESCRIPTION
Add memory-x generation per chip.
- In [parts.rs](data/parts.yaml), each chip contains a vector of memory sections
- Make sure each chip has a FLASH and RAM section for [cortex-m](https://github.com/rust-embedded/cortex-m/blob/master/memory.x)
- Separate SRAM banks to avoid undefined behaviour in case STOP/STANDBY modes are used (in the future)
    - We could have an option to combine them for now
- Generate the memory-x file per chip and add it to the respective directory in mspm0-metapac/src/chips