### PR TITLE
metadata: add power domain info to peripherals

### DIFF
--- a/mspm0-metapac-gen/res/metadata.rs
+++ b/mspm0-metapac-gen/res/metadata.rs
@@ -17,6 +17,7 @@ pub struct Peripheral {
     pub kind: &'static str,
     pub version: Option<&'static str>,
     pub pins: &'static [PeripheralPin],
+    pub power_domain: PowerDomain,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -30,6 +31,20 @@ pub struct PeripheralPin {
     pub pin: &'static str,
     pub signal: &'static str,
     pub pf: Option<u8>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum PowerDomain {
+    /// "low speed" power domain. This power domain is powered in RUN, SLEEP, STOP and STANDBY modes.
+    Pd0,
+
+    /// "high performance" power domain. This power domain is powered in RUN and SLEEP modes.
+    Pd1,
+
+    /// PDB backup power domain. This is usually powered by VBAT.
+    ///
+    /// Not available on every chip.
+    Backup,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/mspm0-metapac-gen/src/metadata.rs
+++ b/mspm0-metapac-gen/src/metadata.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, sync::LazyLock};
 
-use mspm0_data_types::{Chip, Package, Peripheral, PeripheralType};
+use mspm0_data_types::{Chip, Package, Peripheral, PeripheralType, PowerDomain};
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use regex::Regex;
@@ -183,12 +183,19 @@ fn generate_peripheral(
         }
     }
 
+    let power_domain = match peripheral.power_domain {
+        PowerDomain::Pd0 => quote! { PowerDomain::Pd0 },
+        PowerDomain::Pd1 => quote! { PowerDomain::Pd1 },
+        PowerDomain::Backup => quote! { PowerDomain::Backup },
+    };
+
     Some(quote! {
         Peripheral {
             name: #name,
             kind: #kind,
             version: #version,
             pins: &[#(#pins),*],
+            power_domain: #power_domain,
         }
     })
 }


### PR DESCRIPTION
UART will need this to correctly use BusClk