### PR TITLE
peripheral: add fifo size field for the relevant peripherals

### DIFF
--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -228,6 +228,9 @@ pub struct Peripheral {
     pub power_domain: PowerDomain,
 
     pub pins: Vec<PeripheralPin>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sys_fentries: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mspm0-metapac-gen/res/metadata.rs
+++ b/mspm0-metapac-gen/res/metadata.rs
@@ -20,6 +20,7 @@ pub struct Peripheral {
     pub version: Option<&'static str>,
     pub pins: &'static [PeripheralPin],
     pub power_domain: PowerDomain,
+    pub sys_fentries: Option<usize>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/mspm0-metapac-gen/src/metadata.rs
+++ b/mspm0-metapac-gen/src/metadata.rs
@@ -189,6 +189,11 @@ fn generate_peripheral(
         PowerDomain::Backup => quote! { PowerDomain::Backup },
     };
 
+    let sys_fentries = match peripheral.sys_fentries {
+        Some(sys_fentries) => quote! { Some(#sys_fentries) },
+        None => quote! { None },
+    };
+
     Some(quote! {
         Peripheral {
             name: #name,
@@ -196,6 +201,7 @@ fn generate_peripheral(
             version: #version,
             pins: &[#(#pins),*],
             power_domain: #power_domain,
+            sys_fentries: #sys_fentries,
         }
     })
 }


### PR DESCRIPTION
- The field name is 'sys_fentries' (it's borrowed from sysconfig)
- The field value is different across chips and peripherals.
- The field is relevant for I2C, SPI, UART peripherals, for the rest it has 'None' value
- The filed type is usize