### PR TITLE
Fix BOOTWWDT0 in SYSCTL RSTCAUSE ID enum

### DIFF
--- a/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
+++ b/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
@@ -1279,15 +1279,15 @@ enum/ID:
   - name: BOOTEXNRST
     description: NRST triggered BOOTRST (&lt;1s hold).
     value: 12
+  - name: BOOTWWDT0
+    description: WWDT0 violation.
+    value: 14
   - name: SYSBSLEXIT
     description: BSL exit.
     value: 16
   - name: SYSBSLENTRY
     description: BSL entry.
     value: 17
-  - name: SYSWWDT0
-    description: WWDT0 violation.
-    value: 18
   - name: SYSWWDT1
     description: WWDT1 violation.
     value: 19

--- a/data/registers/sysctl_l110x_l130x_l134x.yaml
+++ b/data/registers/sysctl_l110x_l130x_l134x.yaml
@@ -810,18 +810,15 @@ enum/ID:
   - name: BOOTEXNRST
     description: NRST triggered BOOTRST (&lt;1s hold).
     value: 12
+  - name: BOOTWWDT0
+    description: WWDT0 violation.
+    value: 14
   - name: SYSBSLEXIT
     description: BSL exit.
     value: 16
   - name: SYSBSLENTRY
     description: BSL entry.
     value: 17
-  - name: SYSWWDT0
-    description: WWDT0 violation.
-    value: 18
-  - name: SYSWWDT1
-    description: WWDT1 violation.
-    value: 19
   - name: SYSFLASHECC
     description: Flash uncorrectable ECC error.
     value: 20

--- a/data/registers/sysctl_l122x_l222x.yaml
+++ b/data/registers/sysctl_l122x_l222x.yaml
@@ -1191,7 +1191,7 @@ enum/ID:
   - name: BOOTSW
     description: Software triggered BOOTRST.
     value: 13
-  - name: SYSWWDT0
+  - name: BOOTWWDT0
     description: WWDT0 violation.
     value: 14
   - name: SYSBSLEXIT
@@ -1200,9 +1200,6 @@ enum/ID:
   - name: SYSBSLENTRY
     description: BSL entry.
     value: 17
-  - name: SYSWWDT1
-    description: WWDT1 violation.
-    value: 19
   - name: SYSFLASHECC
     description: Flash uncorrectable ECC error.
     value: 20

--- a/transforms/SYSCTL_G350x_G310x_G150x_G110x.yaml
+++ b/transforms/SYSCTL_G350x_G310x_G150x_G110x.yaml
@@ -40,7 +40,16 @@ transforms:
 
   # TODO SYSTEMCFG: Flatten WWDTLP[0..1]RSTDIS
 
-  # TODO RSTCAUSE: Match other chips?
+  # RSTCAUSE.ID.SYSWWDT0 should actually be called BOOTWWDT0 and have a value of 14
+  - !DeleteEnumVariants
+    enum: ID
+    from: SYSWWDT0
+
+  - !AddEnumVariants
+    enum: ID
+    variants:
+    - name: BOOTWWDT0
+      value: 14
 
   # TODO RESETLEVEL: Match other chips?
 

--- a/transforms/SYSCTL_L110x_L130x_L134x.yaml
+++ b/transforms/SYSCTL_L110x_L130x_L134x.yaml
@@ -46,7 +46,7 @@ transforms:
       value: 2
     - name: ANACLKERR
       value: 3
-  
+
   - !AddFields
     fieldset: INT
     fields:
@@ -73,6 +73,18 @@ transforms:
   # TODO: SYSMEMWEPROT, entirely missing from SVDs
   # TODO: SYSSTATUS: Missing FLASHDED, FLASHSEC
   # FIXME: RSTCAUSE has ID enum, but C110x one wasnt set
+
+  # RSTCAUSE.ID.SYSWWDT0 should actually be called BOOTWWDT0 and have a value of 14
+  # RSTCAUSE.ID.SYSWWDT1 does not exist for L-series
+  - !DeleteEnumVariants
+    enum: ID
+    from: (SYSWWDT0|SYSWWDT1)
+
+  - !AddEnumVariants
+    enum: ID
+    variants:
+    - name: BOOTWWDT0
+      value: 14
 
   # RESETCMD: Add KEY
   - !Add

--- a/transforms/SYSCTL_L122x_L222x.yaml
+++ b/transforms/SYSCTL_L122x_L222x.yaml
@@ -38,6 +38,17 @@ transforms:
 
   # TODO: SYSTEMCFG: Add key
 
+  # RSTCAUSE.ID.SYSWWDT0 should actually be called BOOTWWDT0
+  # RSTCAUSE.ID.SYSWWDT1 does not exist for L-series
+  - !RenameEnumVariants
+    enum: ID
+    from: SYSWWDT0
+    to: BOOTWWDT0
+
+  - !DeleteEnumVariants
+    enum: ID
+    from: SYSWWDT1
+
   # RESETCMD: Add KEY
   - !Add
     ir:


### PR DESCRIPTION
The SVD files contain errors for the definition of the SYSCTL RSTCAUSE ID enum:
- The WWDT0 violation reset cause actually has a value of 14 (0x0e) according to the tech references.
- It's actually part of the BOOT reset level, so it should be named BOOTWWDT0 according to the naming conventions in this PAC.
- Only the G-series has a WWDT1 and a corresponding reset cause.

I've added transforms to correct these issues and updated the files in data/registers accordingly.

On a side note, the SVD for the C-series chips doesn't contain the SYSCTL RSTCAUSE register, even though it's described in the C-series tech reference. But I felt correcting this was out-of-scope for this change.