### PR TITLE
Add OPA register block

### DIFF
--- a/data/registers/opa_v1.yaml
+++ b/data/registers/opa_v1.yaml
@@ -1,0 +1,270 @@
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+block/OPA:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    byte_offset: 2048
+    block: GPRCM
+  - name: CLKOVR
+    description: Clock Override.
+    byte_offset: 4112
+    fieldset: CLKOVR
+  - name: PWRCTL
+    description: Power Control.
+    byte_offset: 4124
+    fieldset: PWRCTL
+  - name: CTL
+    description: Control Register.
+    byte_offset: 4352
+    fieldset: CTL
+  - name: CFGBASE
+    description: Configuration Base Register.
+    byte_offset: 4356
+    fieldset: CFGBASE
+  - name: CFG
+    description: Configuration Register.
+    byte_offset: 4360
+    fieldset: CFG
+  - name: STAT
+    description: Status Register.
+    byte_offset: 4376
+    access: Read
+    fieldset: STAT
+fieldset/CFG:
+  description: Configuration Register.
+  fields:
+  - name: CHOP
+    description: Chopping enable.
+    bit_offset: 0
+    bit_size: 2
+    enum: CHOP
+  - name: OUTPIN
+    description: Enable output pin.
+    bit_offset: 2
+    bit_size: 1
+  - name: PSEL
+    description: Positive OA input selection. Please refer to the device specific datasheet for exact channels available.
+    bit_offset: 3
+    bit_size: 4
+    enum: PSEL
+  - name: NSEL
+    description: Negative OA input selection. Please refer to the device specific datasheet for exact channels available.
+    bit_offset: 7
+    bit_size: 3
+    enum: NSEL
+  - name: MSEL
+    description: MSEL Mux selection. Please refer to the device specific datasheet for exact channels available.
+    bit_offset: 10
+    bit_size: 3
+    enum: MSEL
+  - name: GAIN
+    description: Gain setting. Refer to TRM for enumeration information.
+    bit_offset: 13
+    bit_size: 3
+fieldset/CFGBASE:
+  description: Configuration Base Register.
+  fields:
+  - name: GBW
+    description: Select gain bandwidth which affects current as well the gain bandwidth. The lower gain bandwidth has lower current. See device specific datasheet for values. Can only be modified when STAT.BUSY=0.
+    bit_offset: 0
+    bit_size: 1
+    enum: GBW
+  - name: RRI
+    description: Rail-to-rail input enable. Can only be modified when STAT.BUSY=0.
+    bit_offset: 2
+    bit_size: 1
+fieldset/CLKOVR:
+  description: Clock Override.
+  fields:
+  - name: OVERRIDE
+    description: Unlocks the functionality of [RUN_STOP] to override the automatic peripheral clock request.
+    bit_offset: 0
+    bit_size: 1
+  - name: RUN_STOP
+    description: If [OVERRIDE] is enabled, this register is used to manually control the peripheral's clock request to the system.
+    bit_offset: 1
+    bit_size: 1
+    enum: RUN_STOP
+fieldset/CTL:
+  description: Control Register.
+  fields:
+  - name: ENABLE
+    description: OAxn Enable.
+    bit_offset: 0
+    bit_size: 1
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PWRCTL:
+  description: Power Control.
+  fields:
+  - name: AUTO_OFF
+    description: When set the peripheral will remove its local IP request for enable so that it can be disabled if no other entities in the system are requesting it to be enabled.
+    bit_offset: 0
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change.
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key.
+    bit_offset: 24
+    bit_size: 8
+    enum: RSTCTL_KEY
+fieldset/STAT:
+  description: Status Register.
+  fields:
+  - name: RDY
+    description: OA ready status.
+    bit_offset: 0
+    bit_size: 1
+enum/CHOP:
+  bit_size: 2
+  variants:
+  - name: OFF
+    description: Chopping disable.
+    value: 0
+  - name: ON
+    description: Standard chopping enable.
+    value: 1
+  - name: AVGON
+    description: Chop with post average on. Requires output to be connect to ADC in average mode.
+    value: 2
+enum/GBW:
+  bit_size: 1
+  variants:
+  - name: LOWGAIN
+    description: Low gain bandwidth. See device specific datasheet for gain bandwidth.
+    value: 0
+  - name: HIGHGAIN
+    description: High gain bandwidth. See device specific datasheet for gain bandwidth.
+    value: 1
+enum/MSEL:
+  bit_size: 3
+  variants:
+  - name: NC
+    description: no connect.
+    value: 0
+  - name: EXTNPIN1
+    description: external pin OAn-1.
+    value: 1
+  - name: VSS
+    description: VSS.
+    value: 2
+  - name: DAC12OUT
+    description: DAC12 Output.
+    value: 3
+  - name: OANM1RTOP
+    description: OA[n-1]Rtop.
+    value: 4
+enum/NSEL:
+  bit_size: 3
+  variants:
+  - name: NC
+    description: no connect.
+    value: 0
+  - name: EXTPIN0
+    description: external pin OAn-0.
+    value: 1
+  - name: EXTPIN1
+    description: external pin OAn-1.
+    value: 2
+  - name: OANP1RBOT
+    description: OA[n+1]Rbot.
+    value: 3
+  - name: OANRTAP
+    description: OA[n]Rtap.
+    value: 4
+  - name: OANRTOP
+    description: OA[n]Rtop.
+    value: 5
+  - name: SPARE
+    description: Spare input.
+    value: 6
+enum/PSEL:
+  bit_size: 4
+  variants:
+  - name: NC
+    description: No connect.
+    value: 0
+  - name: EXTPIN0
+    description: external pin OA+0.
+    value: 1
+  - name: EXTPIN1
+    description: external pin OAn+1.
+    value: 2
+  - name: DAC12OUT
+    description: DAC12OUT.
+    value: 3
+  - name: DAC8OUT
+    description: DAC8OUT.
+    value: 4
+  - name: VREF
+    description: VREF Channel.
+    value: 5
+  - name: OANM1RTOP
+    description: OA[n-1]Rtop.
+    value: 6
+  - name: GPAMP_OUT_INT
+    description: GPAMP_OUT_INT Input.
+    value: 7
+  - name: VSS
+    description: Internal Ground Connection.
+    value: 8
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RSTCTL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177
+enum/RUN_STOP:
+  bit_size: 1
+  variants:
+  - name: RUN
+    description: Run/ungate functional clock.
+    value: 0
+  - name: STOP
+    description: Stop/gate functional clock.
+    value: 1

--- a/data/registers/opa_v1.yaml
+++ b/data/registers/opa_v1.yaml
@@ -80,12 +80,12 @@ fieldset/CFGBASE:
   description: Configuration Base Register.
   fields:
   - name: GBW
-    description: Select gain bandwidth which affects current as well the gain bandwidth. The lower gain bandwidth has lower current. See device specific datasheet for values. Can only be modified when STAT.BUSY=0.
+    description: Select gain bandwidth which affects current as well the gain bandwidth. The lower gain bandwidth has lower current. See device specific datasheet for values. Can only be modified when STAT.RDY=0.
     bit_offset: 0
     bit_size: 1
     enum: GBW
   - name: RRI
-    description: Rail-to-rail input enable. Can only be modified when STAT.BUSY=0.
+    description: Rail-to-rail input enable. Can only be modified when STAT.RDY=0.
     bit_offset: 2
     bit_size: 1
 fieldset/CLKOVR:
@@ -111,7 +111,7 @@ fieldset/GPRCM_STAT:
   description: Status Register.
   fields:
   - name: RESETSTKY
-    description: This bit indicates if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
     bit_offset: 16
     bit_size: 1
 fieldset/PWRCTL:
@@ -148,7 +148,7 @@ fieldset/RSTCTL:
     description: Unlock key.
     bit_offset: 24
     bit_size: 8
-    enum: RSTCTL_KEY
+    enum: RESET_KEY
 fieldset/STAT:
   description: Status Register.
   fields:
@@ -166,7 +166,7 @@ enum/CHOP:
     description: Standard chopping enable.
     value: 1
   - name: AVGON
-    description: Chop with post average on. Requires output to be connect to ADC in average mode.
+    description: Chop with post average on. Requires output to be connected to ADC in average mode.
     value: 2
 enum/GBW:
   bit_size: 1
@@ -254,7 +254,7 @@ enum/PWREN_KEY:
   variants:
   - name: KEY
     value: 38
-enum/RSTCTL_KEY:
+enum/RESET_KEY:
   bit_size: 8
   variants:
   - name: KEY

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -9,6 +9,7 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:cpuss", "v1"),
     (".*:iomux", "v1"),
     (".*:mathacl", "v1"),
+    (".*:opa", "v1"),
     (".*:tim", "v1"),
     (".*:adc", "v1"),
     (".*:wwdt", "v1"),

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -18,6 +18,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::I2c,
     PeripheralType::Iomux,
     PeripheralType::Mathacl,
+    PeripheralType::Opa,
     PeripheralType::Sysctl,
     PeripheralType::Tim,
     PeripheralType::Trng,

--- a/transforms/OPA.yaml
+++ b/transforms/OPA.yaml
@@ -1,0 +1,115 @@
+# Transform for OPA registers, based on OPA0 on G350x. The OPA0/OPA1 blocks
+# are identical across G150x, G350x, L130x and L134x.
+transforms:
+  - !DeleteUselessEnums
+
+  # Remove specific enum patterns found in the OPA SVD
+  # RESETASSERT
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: ASSERT
+
+  # RESETSTKY
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NORES
+      1: RESET
+
+  # RESETSTKYCLR
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: CLR
+
+  # STAT.RDY
+  - !DeleteEnumsWithVariants
+    variants:
+      0: 'FALSE'
+      1: 'TRUE'
+
+  # CTL.ENABLE
+  - !DeleteEnumsWithVariants
+    variants:
+      0: 'OFF'
+      1: 'ON'
+
+  # CFG.OUTPIN, CLKOVR.OVERRIDE
+  - !DeleteEnumsWithVariants
+    variants:
+      0: DISABLED
+      1: ENABLED
+
+  # PWREN.ENABLE, PWRCTL.AUTO_OFF
+  - !DeleteEnumsWithVariants
+    variants:
+      0: DISABLE
+      1: ENABLE
+
+  # Remove useless prefixes
+  - !Rename
+    type: All
+    from: OPA0_(.+)
+    to: $1
+
+  - !RenameRegisters
+    block: .*
+    from: OPA0_(.+)
+    to: $1
+
+  - !RenameRegisters
+    block: GPRCM
+    from: GPRCM_(.+)
+    to: $1
+
+  - !Rename
+    type: All
+    from: OPA0
+    to: OPA
+
+  # Remove useless array in GPRCM
+  - !DeleteRegisters
+    block: OPA
+    from: GPRCM
+
+  - !AddRegisters
+    block: OPA
+    registers:
+    - name: GPRCM
+      byte_offset: 2048
+      block: GPRCM
+
+  # Add missing KEY fields
+  - !Add
+    ir:
+      enum/PWREN_KEY:
+        bit_size: 8
+        variants:
+        - name: KEY
+          value: 38 #26h
+      enum/RSTCTL_KEY:
+        bit_size: 8
+        variants:
+        - name: KEY
+          value: 177 #B1h
+
+  - !AddFields
+    fieldset: PWREN
+    fields:
+    - name: KEY
+      description: KEY to allow Power State Change.
+      bit_offset: 24
+      bit_size: 8
+      enum: PWREN_KEY
+
+  - !AddFields
+    fieldset: RSTCTL
+    fields:
+    - name: KEY
+      description: Unlock key.
+      bit_offset: 24
+      bit_size: 8
+      enum: RSTCTL_KEY
+
+  # Cleanup
+  - !Sort

--- a/transforms/OPA.yaml
+++ b/transforms/OPA.yaml
@@ -3,7 +3,7 @@
 transforms:
   - !DeleteUselessEnums
 
-  # Remove specific enum patterns found in the OPA SVD
+  # Enum patterns DeleteUselessEnums does not catch (same set as TRNG):
   # RESETASSERT
   - !DeleteEnumsWithVariants
     variants:
@@ -21,30 +21,6 @@ transforms:
     variants:
       0: NOP
       1: CLR
-
-  # STAT.RDY
-  - !DeleteEnumsWithVariants
-    variants:
-      0: 'FALSE'
-      1: 'TRUE'
-
-  # CTL.ENABLE
-  - !DeleteEnumsWithVariants
-    variants:
-      0: 'OFF'
-      1: 'ON'
-
-  # CFG.OUTPIN, CLKOVR.OVERRIDE
-  - !DeleteEnumsWithVariants
-    variants:
-      0: DISABLED
-      1: ENABLED
-
-  # PWREN.ENABLE, PWRCTL.AUTO_OFF
-  - !DeleteEnumsWithVariants
-    variants:
-      0: DISABLE
-      1: ENABLE
 
   # Remove useless prefixes
   - !Rename
@@ -79,7 +55,7 @@ transforms:
       byte_offset: 2048
       block: GPRCM
 
-  # Add missing KEY fields
+  # Add missing KEY fields (not present in the SVDs)
   - !Add
     ir:
       enum/PWREN_KEY:
@@ -87,7 +63,7 @@ transforms:
         variants:
         - name: KEY
           value: 38 #26h
-      enum/RSTCTL_KEY:
+      enum/RESET_KEY:
         bit_size: 8
         variants:
         - name: KEY
@@ -109,7 +85,99 @@ transforms:
       description: Unlock key.
       bit_offset: 24
       bit_size: 8
-      enum: RSTCTL_KEY
+      enum: RESET_KEY
+
+  # SVD description fixes. The GBW/RRI descriptions reference a STAT.BUSY
+  # bit that does not exist; the TRM shows the busy/ready status is STAT.RDY.
+  - !DeleteFields
+    fieldset: CFGBASE
+    from: GBW
+
+  - !AddFields
+    fieldset: CFGBASE
+    fields:
+    - name: GBW
+      description: Select gain bandwidth which affects current as well the gain bandwidth. The lower gain bandwidth has lower current. See device specific datasheet for values. Can only be modified when STAT.RDY=0.
+      bit_offset: 0
+      bit_size: 1
+      enum: GBW
+
+  - !DeleteFields
+    fieldset: CFGBASE
+    from: RRI
+
+  - !AddFields
+    fieldset: CFGBASE
+    fields:
+    - name: RRI
+      description: Rail-to-rail input enable. Can only be modified when STAT.RDY=0.
+      bit_offset: 2
+      bit_size: 1
+
+  # More SVD description typos ("connect" -> "connected", "Grouund").
+  - !DeleteEnums
+    from: CHOP
+
+  - !Add
+    ir:
+      enum/CHOP:
+        bit_size: 2
+        variants:
+        - name: OFF
+          description: Chopping disable.
+          value: 0
+        - name: 'ON'
+          description: Standard chopping enable.
+          value: 1
+        - name: AVGON
+          description: Chop with post average on. Requires output to be connected to ADC in average mode.
+          value: 2
+
+  - !ModifyFieldsEnum
+    fieldset: CFG
+    field: CHOP
+    enum: CHOP
+
+  - !DeleteEnums
+    from: PSEL
+
+  - !Add
+    ir:
+      enum/PSEL:
+        bit_size: 4
+        variants:
+        - name: NC
+          description: No connect.
+          value: 0
+        - name: EXTPIN0
+          description: external pin OA+0.
+          value: 1
+        - name: EXTPIN1
+          description: external pin OAn+1.
+          value: 2
+        - name: DAC12OUT
+          description: DAC12OUT.
+          value: 3
+        - name: DAC8OUT
+          description: DAC8OUT.
+          value: 4
+        - name: VREF
+          description: VREF Channel.
+          value: 5
+        - name: OANM1RTOP
+          description: OA[n-1]Rtop.
+          value: 6
+        - name: GPAMP_OUT_INT
+          description: GPAMP_OUT_INT Input.
+          value: 7
+        - name: VSS
+          description: Internal Ground Connection.
+          value: 8
+
+  - !ModifyFieldsEnum
+    fieldset: CFG
+    field: PSEL
+    enum: PSEL
 
   # Cleanup
   - !Sort


### PR DESCRIPTION
This adds the register block for the OPA (zero-drift op-amp) found on the G150x, G350x, L130x and L134x families.

Extracted with `./d extract-all OPA0` (and OPA1 to double check). The yamls from all four SVDs came out byte-identical apart from the instance prefix, so there's a single `opa_v1`. Cleanup follows what trng/wwdt already do: instance prefixes stripped, single-bit enable/status enums dropped, and the KEY fields on PWREN/RSTCTL added by hand since the SVDs omit them (same values as every other GPRCM block, 0x26 and 0xB1).

One thing worth a second look: the SVDs don't carry a BUSY bit in STAT even though the CFGBASE field descriptions reference STAT.BUSY. I left the yaml matching the SVD.

Ran `./d gen && ./d build-metapac` and built the resulting metapac for mspm0g3507pm and mspm0l1306dgs28. The generated block is also exercised by an embassy-mspm0 OPA driver I have queued up (ozongzi/embassy branch `mspm0-opa`), which I've hardware-tested on an LP-MSPM0G3507: every PGA gain step verified against the on-chip DAC and ADC, gains land within 2% of nominal. I'll send that PR once this lands and a new tag is cut.