### PR TITLE
Fix typo in l1305 and l110x package types

### DIFF
--- a/data/parts.yaml
+++ b/data/parts.yaml
@@ -513,7 +513,7 @@ families:
     - DGS28
     - DYY
     - RGE
-    - RGB
+    - RHB
     - RTR
 
   - name: mspm0l1106
@@ -662,7 +662,7 @@ families:
     - DGS28
     - DYY
     - RGE
-    - RGB
+    - RHB
     - RTR
 
   - name: mspm0l1306

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -34,10 +34,7 @@ pub fn generate(
         let sysconfig = sysconfig
             .files
             .get(&family.family.to_uppercase())
-            .context(format!(
-                "No sysconfig data available for {}",
-                &family.family
-            ))?;
+            .context(format!("No sysconfig data available for {}", family.family))?;
 
         // MSPS003FX is the same as C110X except for package options and some pins.
         let header_name = if family.family == "msps003fx" {
@@ -118,7 +115,7 @@ fn generate_family(
         let data = serde_json::to_string_pretty(&chip)
             .context(format!("Serializing chip {}", part_number.name))?;
 
-        fs::write(format!("./build/data/{}.json", &part_number.name), data)
+        fs::write(format!("./build/data/{}.json", part_number.name), data)
             .context(format!("Error writing data for {}", part_number.name))?;
     }
 
@@ -260,7 +257,7 @@ fn generate_peripherals2(
             // IWDT technically exists on G151x and G351x, but the SDK and datasheets do not define the address for IWDT.
             //
             // To prevent issues, we will only consider IWDT to exist on chips which define an address.
-            if name == "IWDT" && header.peripheral_addresses.get(&name).is_none() {
+            if name == "IWDT" && !header.peripheral_addresses.contains_key(&name) {
                 continue;
             }
 
@@ -836,13 +833,15 @@ fn generate_adc_memctl_dim(chip_name: &str, sysconfig: &SysconfigFile) -> anyhow
         // make names consistent sometimes
         let name = maybe_rename(name);
 
-        let raw_memctl_dim = &peripheral.attributes.get("SYS_ADC_MEMCTL_DIM").expect(
-            format!(
-                "SYS_ADC_MEMCTL_DIM should exist for {} in {}",
-                name, chip_name
-            )
-            .as_str(),
-        );
+        let raw_memctl_dim = &peripheral
+            .attributes
+            .get("SYS_ADC_MEMCTL_DIM")
+            .unwrap_or_else(|| {
+                panic!(
+                    "SYS_ADC_MEMCTL_DIM should exist for {} in {}",
+                    name, chip_name
+                )
+            });
         let memctl_error = format!(
             "SYS_ADC_MEMCTL_DIM: {} should be an u32 as string for {} in {}",
             raw_memctl_dim, name, chip_name

--- a/mspm0-data-gen/src/header.rs
+++ b/mspm0-data-gen/src/header.rs
@@ -23,7 +23,7 @@ impl Headers {
         for header in glob::glob(&format!("{}/mspm0*.h", header_path.display())).unwrap() {
             let header = header.unwrap();
             // Two assignments to make the borrow checker happy
-            let name = header.components().last().unwrap().as_os_str();
+            let name = header.components().next_back().unwrap().as_os_str();
             let name = name.to_string_lossy();
 
             let name = name.split(".h").next().unwrap();

--- a/mspm0-metapac-gen/src/linker.rs
+++ b/mspm0-metapac-gen/src/linker.rs
@@ -13,7 +13,7 @@ pub fn generate_device_x(name: &str, chip: &Chip, out_dir: &Path) -> anyhow::Res
     let path = dir.join("device.x");
     let mut file = File::create(&path)?;
 
-    for (_, interrupt) in chip.interrupts.iter() {
+    for interrupt in chip.interrupts.values() {
         if interrupt.num < 0 {
             continue;
         }

--- a/mspm0-metapac-gen/src/metadata.rs
+++ b/mspm0-metapac-gen/src/metadata.rs
@@ -77,7 +77,7 @@ pub fn dma_channels(chip: &Chip) -> TokenStream {
 pub fn interrupts(chip: &Chip) -> TokenStream {
     let mut interrupts = Vec::new();
 
-    for (_, interrupt) in chip.interrupts.iter() {
+    for interrupt in chip.interrupts.values() {
         // Skip interrupts handled by cortex-m
         if interrupt.num < 0 {
             continue;
@@ -102,7 +102,7 @@ pub fn interrupts(chip: &Chip) -> TokenStream {
 pub fn interrupt_groups(chip: &Chip) -> TokenStream {
     let mut groups = Vec::new();
 
-    for (_, interrupt) in chip.interrupts.iter() {
+    for interrupt in chip.interrupts.values() {
         // Skip interrupts handled by cortex-m
         if interrupt.num < 0 {
             continue;

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -42,8 +42,8 @@ fn generate_peripheral_imports(
 ) -> TokenStream {
     // Sort the peripherals by type for generation.
     let mut peripheral_types = chip.peripherals.iter().collect::<Vec<_>>();
-    peripheral_types.sort_by(|(a, _), (b, _)| a.cmp(b));
-    peripheral_types.dedup_by(|(_, a), (_, b)| a.ty == b.ty);
+    peripheral_types.sort_by_key(|(a, _)| *a);
+    peripheral_types.dedup_by_key(|(_, v)| v.ty);
 
     peripheral_types
         .iter()

--- a/mspm0-metapac-gen/src/registers.rs
+++ b/mspm0-metapac-gen/src/registers.rs
@@ -29,6 +29,8 @@ pub fn generate(out_dir: &Path) -> anyhow::Result<()> {
         common_module: CommonModule::External(TokenStream::from_str("crate::common").unwrap()),
     };
 
+    let re = Regex::new("# *! *\\[.*\\]").unwrap();
+
     for f in glob::glob("data/registers/*").unwrap() {
         let f = f.unwrap();
 
@@ -87,7 +89,6 @@ pub fn generate(out_dir: &Path) -> anyhow::Result<()> {
         .unwrap();
 
         let items = items.to_string().replace("] ", "]\n");
-        let re = Regex::new("# *! *\\[.*\\]").unwrap();
         let items = re.replace_all(&items, "");
         writeln!(file, "{items}").unwrap();
 


### PR DESCRIPTION
I'm using the RHB variant of the MSPM0L1305 and noticed that it was missing from the embassy-mspm0 features - I believe this is the cause