### PR TITLE
Add FACTORYREGION peripheral

### DIFF
--- a/data/registers/factoryregion_v1.yaml
+++ b/data/registers/factoryregion_v1.yaml
@@ -1,0 +1,257 @@
+block/FACTORYREGION:
+  description: Customer-visible factory constants (IDs, PLL trims, calibration).
+  items:
+  - name: TRACEID
+    description: Defined by TI, during ATE, based on wafer.
+    byte_offset: 0
+    access: Read
+  - name: DEVICEID
+    description: This is the JTAGIDCODE that comes from the Ramp system.
+    byte_offset: 4
+    access: Read
+    fieldset: DEVICEID
+  - name: USERID
+    description: Defined by TI, depending on device spin.
+    byte_offset: 8
+    access: Read
+    fieldset: USERID
+  - name: BSLPIN_UART
+    description: BSL UART Pin Configuration.
+    byte_offset: 12
+    access: Read
+    fieldset: BSLPIN_UART
+  - name: BSLPIN_I2C
+    description: BSL I2C Pin Configuration.
+    byte_offset: 16
+    access: Read
+    fieldset: BSLPIN_I2C
+  - name: BSLPIN_INVOKE
+    description: BSL Pin Invocation Configuration.
+    byte_offset: 20
+    access: Read
+    fieldset: BSLPIN_INVOKE
+  - name: SRAMFLASH
+    description: SRAM and flash sizes.
+    byte_offset: 24
+    access: Read
+    fieldset: SRAMFLASH
+  - name: PLLSTARTUP0_4_8MHZ
+    description: System PLL Parameter 0 MMR for a 4 to 8 MHz reference clock.
+    byte_offset: 28
+    access: Read
+    fieldset: PLLSTARTUP0
+  - name: PLLSTARTUP1_4_8MHZ
+    description: System PLL Parameter 1 MMR for a 4 to 8 MHz reference clock.
+    byte_offset: 32
+    access: Read
+    fieldset: PLLSTARTUP1
+  - name: PLLSTARTUP0_8_16MHZ
+    description: System PLL Parameter 0 MMR for a 8 to 16 MHz reference clock.
+    byte_offset: 36
+    access: Read
+    fieldset: PLLSTARTUP0
+  - name: PLLSTARTUP1_8_16MHZ
+    description: System PLL Parameter 1 MMR for a 8 to 16 MHz reference clock.
+    byte_offset: 40
+    access: Read
+    fieldset: PLLSTARTUP1
+  - name: PLLSTARTUP0_16_32MHZ
+    description: System PLL Parameter 0 MMR for a 16 to 32 MHz reference clock.
+    byte_offset: 44
+    access: Read
+    fieldset: PLLSTARTUP0
+  - name: PLLSTARTUP1_16_32MHZ
+    description: System PLL Parameter 1 MMR for a 16 to 32 MHz reference clock.
+    byte_offset: 48
+    access: Read
+    fieldset: PLLSTARTUP1
+  - name: PLLSTARTUP0_32_48MHZ
+    description: System PLL Parameter 0 MMR for a 32 to 48 MHz reference clock.
+    byte_offset: 52
+    access: Read
+    fieldset: PLLSTARTUP0
+  - name: PLLSTARTUP1_32_48MHZ
+    description: System PLL Parameter 1 MMR for a 32 to 48 MHz reference clock.
+    byte_offset: 56
+    access: Read
+    fieldset: PLLSTARTUP1
+  - name: TEMP_SENSE0
+    description: Temperature sensor room temperature calibration code. This is the ADC conversion result of the temperature sensor output voltage. Included in BOOTCRC calculation.
+    byte_offset: 60
+    access: Read
+  - name: BOOTCRC
+    description: BOOTCRC records the 32-bit CRC of all locations in OPEN including reserved locations.
+    byte_offset: 124
+    access: Read
+fieldset/BSLPIN_I2C:
+  description: BSL I2C Pin Configuration.
+  fields:
+  - name: I2C_SDA_PAD
+    description: I2C SDA Pin used by BSL.
+    bit_offset: 0
+    bit_size: 8
+  - name: I2C_SDA_PF
+    description: I2C SDA Pin Function Selection Value.
+    bit_offset: 8
+    bit_size: 8
+  - name: I2C_SCL_PAD
+    description: I2C SCL Pin used by BSL.
+    bit_offset: 16
+    bit_size: 8
+  - name: I2C_SCL_PF
+    description: I2C SCL Pin Function Selection Value.
+    bit_offset: 24
+    bit_size: 8
+fieldset/BSLPIN_INVOKE:
+  description: BSL Pin Invocation Configuration.
+  fields:
+  - name: BSL_PAD
+    description: BSL Invocation Pin Number.
+    bit_offset: 0
+    bit_size: 7
+  - name: GPIO_LEVEL
+    description: GPIO Level Configuration for BSL Invocation.
+    bit_offset: 7
+    bit_size: 1
+  - name: GPIO_PIN_SEL
+    description: GPIO Pin Number in GPIO Module.
+    bit_offset: 8
+    bit_size: 5
+  - name: GPIO_REG_SEL
+    description: GPIO Module Selection.
+    bit_offset: 13
+    bit_size: 2
+fieldset/BSLPIN_UART:
+  description: BSL UART Pin Configuration.
+  fields:
+  - name: UART_RXD_PAD
+    description: UART RXD Pad used by BSL.
+    bit_offset: 0
+    bit_size: 8
+  - name: UART_RXD_PF
+    description: UART RXD Pin Function Selection Value.
+    bit_offset: 8
+    bit_size: 8
+  - name: UART_TXD_PAD
+    description: UART TXD Pin used by BSL.
+    bit_offset: 16
+    bit_size: 8
+  - name: UART_TXD_PF
+    description: UART TXD Pin Function Selection Value.
+    bit_offset: 24
+    bit_size: 8
+fieldset/DEVICEID:
+  description: This is the JTAGIDCODE that comes from the Ramp system.
+  fields:
+  - name: ALWAYS_1
+    description: This is always 1.
+    bit_offset: 0
+    bit_size: 1
+  - name: MANUFACTURER
+    description: TI's JEDEC bank and company code.
+    bit_offset: 1
+    bit_size: 11
+  - name: PARTNUM
+    description: Part number of the device.
+    bit_offset: 12
+    bit_size: 16
+  - name: VERSION
+    description: Revision of the device.
+    bit_offset: 28
+    bit_size: 4
+fieldset/PLLSTARTUP0:
+  description: System PLL Parameter 0 MMR.
+  fields:
+  - name: STARTTIME
+    description: Startup time from Enable to Locked Clock in resolution of 1usec.
+    bit_offset: 0
+    bit_size: 6
+  - name: STARTTIMELP
+    description: Startup time from Low Power Exit to Locked Clock in resolution of 1usec.
+    bit_offset: 8
+    bit_size: 6
+  - name: CPCURRENT
+    description: Charge Pump Current.
+    bit_offset: 16
+    bit_size: 6
+  - name: CAPBVAL
+    description: Override Value for Cap B.
+    bit_offset: 24
+    bit_size: 5
+  - name: CAPBOVERRIDE
+    description: Override Enable For Cap B.
+    bit_offset: 31
+    bit_size: 1
+fieldset/PLLSTARTUP1:
+  description: System PLL Parameter 1 MMR.
+  fields:
+  - name: LPFCAPA
+    description: Loop Filter Cap A.
+    bit_offset: 0
+    bit_size: 5
+  - name: LPFRESA
+    description: Loop Filter Res A.
+    bit_offset: 8
+    bit_size: 10
+  - name: LPFRESC
+    description: Loop Filter Res C.
+    bit_offset: 24
+    bit_size: 8
+fieldset/SRAMFLASH:
+  description: SRAM and flash sizes.
+  fields:
+  - name: MAINFLASH_SZ
+    description: Size of main flash in KB.
+    bit_offset: 0
+    bit_size: 12
+  - name: MAINNUMBANKS
+    description: Number of banks in main flash.
+    bit_offset: 12
+    bit_size: 2
+    enum: MAINNUMBANKS
+  - name: SRAM_SZ
+    description: Size of SRAM in KB.
+    bit_offset: 16
+    bit_size: 10
+  - name: DATAFLASH_SZ
+    description: Size of data flash in KB.
+    bit_offset: 26
+    bit_size: 6
+fieldset/USERID:
+  description: Defined by TI, depending on device spin.
+  fields:
+  - name: PART
+    description: Bit pattern that uniquely identifies the part number of the device.
+    bit_offset: 0
+    bit_size: 16
+  - name: VARIANT
+    description: Bit pattern uniquely identifying a variant of the part number.
+    bit_offset: 16
+    bit_size: 8
+  - name: MINORREV
+    description: Monotonic increasing value indicating the minor revision of the device.
+    bit_offset: 24
+    bit_size: 4
+  - name: MAJORREV
+    description: Monotonic increasing value indicating the major revision of the device.
+    bit_offset: 28
+    bit_size: 3
+  - name: START
+    description: Start bit.
+    bit_offset: 31
+    bit_size: 1
+enum/MAINNUMBANKS:
+  bit_size: 2
+  variants:
+  - name: ONEBANK
+    description: One bank.
+    value: 0
+  - name: TWOBANKS
+    description: Two banks.
+    value: 1
+  - name: THREEBANKS
+    description: Three banks.
+    value: 2
+  - name: FOURBANKS
+    description: Four banks.
+    value: 3

--- a/data/registers/factoryregion_v1.yaml
+++ b/data/registers/factoryregion_v1.yaml
@@ -143,10 +143,6 @@ fieldset/BSLPIN_UART:
 fieldset/DEVICEID:
   description: This is the JTAGIDCODE that comes from the Ramp system.
   fields:
-  - name: ALWAYS_1
-    description: This is always 1.
-    bit_offset: 0
-    bit_size: 1
   - name: MANUFACTURER
     description: TI's JEDEC bank and company code.
     bit_offset: 1

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -530,6 +530,29 @@ fn generate_missing(
         },
     );
 
+    // FACTORYREGION is not described in sysconfig, but every SDK header defines its address.
+    let version = PERIMAP
+        .get(&format!("{}:{}", chip_name, PeripheralType::FactoryRegion))
+        .map(|s| s.to_string());
+    let address = header
+        .peripheral_addresses
+        .get("FACTORYREGION")
+        .copied()
+        .context(format!("{chip_name}: FACTORYREGION must have address"))?;
+    peripherals.insert(
+        "FACTORYREGION".to_string(),
+        Peripheral {
+            name: "FACTORYREGION".to_string(),
+            ty: PeripheralType::FactoryRegion,
+            version,
+            address: Some(address),
+            // FACTORYREGION is read-only flash which is always available.
+            power_domain: PowerDomain::Pd1,
+            pins: vec![],
+            sys_fentries: None,
+        },
+    );
+
     // Some devices duplicate the pins multiple times (such as C110x with PA1 and NRST sharing the same physical pin).
     let mut device_pins = BTreeSet::new();
 

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -16,6 +16,7 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:flashctl", "v1"),
     (".*:trng", "v1"),
     (".*:canfd", "v1"),
+    (".*:factoryregion", "v1"),
     ("mspm0c110x:sysctl", "c110x"),
     ("mspm0c1105_c1106:sysctl", "c110x"),
     ("msps003fx:sysctl", "c110x"),

--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -117,6 +117,10 @@ pub enum PeripheralType {
 
     Event,
 
+    /// This region contains read-only device constants such as the device id, flash and SRAM
+    /// sizes and calibration values.
+    FactoryRegion,
+
     FlashCtl,
 
     GpAmp,
@@ -185,6 +189,7 @@ impl fmt::Display for PeripheralType {
             PeripheralType::Debugss => "debugss",
             PeripheralType::Dma => "dma",
             PeripheralType::Event => "event",
+            PeripheralType::FactoryRegion => "factoryregion",
             PeripheralType::FlashCtl => "flashctl",
             PeripheralType::GpAmp => "gpamp",
             PeripheralType::Gpio => "gpio",

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -13,6 +13,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Cpuss,
     PeripheralType::Dma,
     PeripheralType::Canfd,
+    PeripheralType::FactoryRegion,
     PeripheralType::FlashCtl,
     PeripheralType::Gpio,
     PeripheralType::I2c,


### PR DESCRIPTION
The factory region is not described in the sysconfig metadata, but every SDK header defines FACTORYREGION_BASE at the same address, so it is added in "generate_missing" function.

.YAML file is hand written from hw_factoryregion.h since no SVD describes the region.

Note: MSPM0G352X swaps TRACEID and USERID. That family is not in parts.yaml yet, so it will need a factoryregion_gx52x when it is added.