### PR TITLE
Register blocks: cleanup sweep, six new blocks, SYSCTL corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ When parsing a chip, for each peripheral a "key" string is constructed using thi
 ("mspm0c110x:sysctl", ("sysctl", "c110x")),
 ("mspm0g..0x:sysctl", ("sysctl", "g350x_g310x_g150x_g110x")),
 ```
+
+`PERIPHERAL_NAME` is the peripheral type, so every instance of a type on a chip gets the same
+version. Where one type covers instances with different register blocks the key has to say which,
+as `timb` does for the basic timers alongside `tim` — see `get_peripheral_type_version`. Such a
+version also needs an entry in `VARIANT_MODULES` in
+[`peripheral.rs`](./mspm0-metapac-gen/src/peripheral.rs) to give it a module name of its own,
+otherwise the metapac generator panics on the two blocks colliding.

--- a/data/registers/README.md
+++ b/data/registers/README.md
@@ -1,0 +1,56 @@
+# Register blocks
+
+These files are [chiptool](https://github.com/embassy-rs/chiptool) IR. They start life as
+`chiptool extract-peripheral` output from the SVDs in `sources/svd/`, but **the checked-in YAML is
+the source of truth**, not the SVD: it is hand-cleaned afterwards, and in the places listed below it
+deliberately contradicts the SVD. The cleanup rules are in the [root README](../../README.md).
+
+Keep this file up to date rather than commenting the YAML. `chiptool fmt` silently strips comments,
+so anything recorded only there is one `fmt` away from being lost — which is also why a deviation
+that is not written down here tends to get "corrected" back to the SVD by the next person.
+
+Notes about what a register *means*, as opposed to where its definition came from, belong in the
+`description:` text instead. Those survive `fmt` and reach the generated PAC's documentation.
+
+## Deviations from the SVD
+
+Each entry says what the SVD claims, what this repo says instead, and what the evidence is.
+
+### `sysctl_c110x`, `sysctl_c1105_c1106` — three unlock-protected control bits are at bit 0
+
+| fieldset | field |
+| --- | --- |
+| `EXLFCTL` | `SETUSEEXLF` |
+| `EXRSTPIN` | `DISABLE` |
+| `SYSSTATUSCLR` | `ALLECC` |
+
+The C-series SVD puts each of these at bit 2. That contradicts SLAU893 and every other family's
+SYSCTL, which agree on bit 0. Taking the SVD's word for it would produce a HAL whose writes to these
+three registers never take effect.
+
+### `sysctl_l110x_l130x_l134x` — `RSTCAUSE.BOOTSW` is 13
+
+The SVD says 10, copied from SLAU847's field description for this SYSCTL variant. That description
+contradicts the same TRM's "Reset Causes" table, which lists 10 as reserved and 13 as the
+software-triggered BOOTRST. Every other family agrees with the table. `BOOTWWDT0` in the same enum
+had already been corrected against that table for the same reason.
+
+### `cpuss_v1` — the interrupt group's `MIS`, `ISET` and `ICLR` are 8 bits
+
+The SVD gives these three a single bit, where it gives `IMASK` and `RIS` eight. `hw_cpuss.h` masks
+all five with `0xFF`, and the group's `IIDX` enumerates `INT0` to `INT7`, so a single bit would leave
+only interrupt 0 reachable through three of the five registers.
+
+### `gpio_v1` — the generic event masks are indexed by absolute DIO number
+
+The SVD bases both generic event blocks at bit 0 with sixteen bits each. `hw_gpio.h` puts
+`GEN_EVENT0`'s `DIO0` to `DIO15` at bits 0 to 15 but `GEN_EVENT1`'s `DIO16` to `DIO31` at bits **16
+to 31**. Both blocks now share the same 32-bit fieldset as `CPU_INT` and the `DOUT`/`DIN` masks, so
+one bit index means one DIO number everywhere; each event block implements only its own half.
+
+### `tim_v1` — `CCD` and `CCU` are offset-list arrays
+
+Not a contradiction, but the reason a plain stride does not appear here: capture/compare channels 4
+and 5 are compare-only and sit *above* the `CCU` bits rather than next to `CCD0` to `CCD3`
+(`CCD` at bits 4-7 and 12-13, `CCU` at 8-11 and 14-15, per `hw_gptimer.h`). The arrays use chiptool's
+explicit `offsets:` list so that `ccd(n)` and `ccu(n)` still take a channel number.

--- a/data/registers/README.md
+++ b/data/registers/README.md
@@ -12,6 +12,23 @@ that is not written down here tends to get "corrected" back to the SVD by the ne
 Notes about what a register *means*, as opposed to where its definition came from, belong in the
 `description:` text instead. Those survive `fmt` and reach the generated PAC's documentation.
 
+## How much of this is reproducible
+
+Not all of it. `transforms/` gets a block most of the way there, but **re-running a transform does
+not reproduce the checked-in YAML**, so it cannot be treated as a regeneration step:
+
+- Seven blocks have no transform at all and are maintained entirely by hand: `beeper_v1`,
+  `cpuss_v1`, `factoryregion_v1`, `sysctl_c1105_c1106`, `tim_btimer`, `unicomm_v1`, `vref_v1`.
+- Where a transform does exist, the deviations below are not in it. Running the C110x SYSCTL
+  transform over `MSPM0C110X.svd` reproduces the checked-in block *except* for exactly the three
+  fields listed under it, which come out at the SVD's bit 2.
+- The cleanup work — arrays, shared fieldsets, deleted enums — is hand-applied on top and is not
+  encoded in the transforms either.
+
+So a transform is a starting point for a *new* block, not something to re-run over an existing one:
+doing that discards the hand work silently. Diff the output against the checked-in YAML instead, and
+use the flatten-and-compare check described in the root README to see what actually moved.
+
 ## Deviations from the SVD
 
 Each entry says what the SVD claims, what this repo says instead, and what the evidence is.

--- a/data/registers/README.md
+++ b/data/registers/README.md
@@ -14,20 +14,30 @@ Notes about what a register *means*, as opposed to where its definition came fro
 
 ## How much of this is reproducible
 
-Not all of it. `transforms/` gets a block most of the way there, but **re-running a transform does
-not reproduce the checked-in YAML**, so it cannot be treated as a regeneration step:
+Some of it. `transforms/` gets a block most of the way there, and two of the deviations below are now
+encoded in it and verified end to end:
 
-- Seven blocks have no transform at all and are maintained entirely by hand: `beeper_v1`,
-  `cpuss_v1`, `factoryregion_v1`, `sysctl_c1105_c1106`, `tim_btimer`, `unicomm_v1`, `vref_v1`.
-- Where a transform does exist, the deviations below are not in it. Running the C110x SYSCTL
-  transform over `MSPM0C110X.svd` reproduces the checked-in block *except* for exactly the three
-  fields listed under it, which come out at the SVD's bit 2.
-- The cleanup work — arrays, shared fieldsets, deleted enums — is hand-applied on top and is not
-  encoded in the transforms either.
+| block | reproduces the checked-in YAML? |
+| --- | --- |
+| `sysctl_c110x` | **yes** — `chiptool extract-peripheral --svd sources/svd/MSPM0C110X.svd --peripheral SYSCTL`, then `transforms/transform.sh` with `SYSCTL_C110x.yaml` |
+| `sysctl_l110x_l130x_l134x` | **yes** — same, from `MSPM0L130X.svd` |
+| everything else with a transform | no, see below |
+| `beeper_v1`, `cpuss_v1`, `factoryregion_v1`, `sysctl_c1105_c1106`, `tim_btimer`, `unicomm_v1`, `vref_v1` | no transform exists at all |
 
-So a transform is a starting point for a *new* block, not something to re-run over an existing one:
-doing that discards the hand work silently. Diff the output against the checked-in YAML instead, and
-use the flatten-and-compare check described in the root README to see what actually moved.
+Where a transform does not reproduce its block, the reason is usually that it is written against a
+different source instance than the one the block was derived from — `TIM.yaml` runs from `TIMA0` on
+MSPM0G350X, which has four capture/compare channels and neither the `DC` nor the `QEIERR` event, so
+its output cannot match `tim_v1` however the transform is written. Closing those gaps means
+re-deriving the block, not just editing the transform.
+
+The rest of the cleanup — shared fieldsets, deleted enums, stripped prefixes — is hand-applied on top
+and is not encoded anywhere. **Re-running a transform over an existing block therefore discards hand
+work silently.** Diff the output against the checked-in YAML instead, and use the flatten-and-compare
+check described in the root README to see what actually moved.
+
+The exception worth copying is `TIM.yaml`'s `CCD`/`CCU` step: `!MakeFieldArray` with `mode: Cursed`
+produces exactly the offset lists the checked-in block carries, so that piece of the cleanup at least
+survives a re-derivation.
 
 ## Deviations from the SVD
 

--- a/data/registers/README.md
+++ b/data/registers/README.md
@@ -1,56 +1,43 @@
 # Register blocks
 
 These files are [chiptool](https://github.com/embassy-rs/chiptool) IR. They start life as
-`chiptool extract-peripheral` output from the SVDs in `sources/svd/`, but **the checked-in YAML is
-the source of truth**, not the SVD: it is hand-cleaned afterwards, and in the places listed below it
+`chiptool extract-peripheral` output from the SVDs in `sources/svd/`. The checked-in YAML is the
+source of truth, not the SVD. It is hand-cleaned afterwards, and in the places listed below it
 deliberately contradicts the SVD. The cleanup rules are in the [root README](../../README.md).
 
-Keep this file up to date rather than commenting the YAML. `chiptool fmt` silently strips comments,
-so anything recorded only there is one `fmt` away from being lost — which is also why a deviation
-that is not written down here tends to get "corrected" back to the SVD by the next person.
+Keep this file up to date rather than commenting the YAML. `chiptool fmt` silently strips comments.
 
-Notes about what a register *means*, as opposed to where its definition came from, belong in the
-`description:` text instead. Those survive `fmt` and reach the generated PAC's documentation.
+Notes about what a register means belong in its `description:` text instead. Those survive `fmt` and
+reach the generated PAC's documentation.
 
 ## How much of this is reproducible
 
-Some of it. `transforms/` gets a block most of the way there, and two of the deviations below are now
-encoded in it and verified end to end:
+Not all of it, so re-running a transform over an existing block discards hand work silently.
+
+`transforms/` gets a block most of the way there. Two of the deviations below are encoded in it and
+verified end to end:
 
 | block | reproduces the checked-in YAML? |
 | --- | --- |
-| `sysctl_c110x` | **yes** — `chiptool extract-peripheral --svd sources/svd/MSPM0C110X.svd --peripheral SYSCTL`, then `transforms/transform.sh` with `SYSCTL_C110x.yaml` |
-| `sysctl_l110x_l130x_l134x` | **yes** — same, from `MSPM0L130X.svd` |
+| `sysctl_c110x` | yes: `chiptool extract-peripheral --svd sources/svd/MSPM0C110X.svd --peripheral SYSCTL`, then `transforms/transform.sh` with `SYSCTL_C110x.yaml` |
+| `sysctl_l110x_l130x_l134x` | yes: same, from `MSPM0L130X.svd` |
 | everything else with a transform | no, see below |
 | `beeper_v1`, `cpuss_v1`, `factoryregion_v1`, `sysctl_c1105_c1106`, `tim_btimer`, `unicomm_v1`, `vref_v1` | no transform exists at all |
 
-Where a transform does not reproduce its block, the reason is usually that it is written against a
-different source instance than the one the block was derived from — `TIM.yaml` runs from `TIMA0` on
-MSPM0G350X, which has four capture/compare channels and neither the `DC` nor the `QEIERR` event, so
-its output cannot match `tim_v1` however the transform is written. Closing those gaps means
-re-deriving the block, not just editing the transform.
-
-The rest of the cleanup — shared fieldsets, deleted enums, stripped prefixes — is hand-applied on top
-and is not encoded anywhere. **Re-running a transform over an existing block therefore discards hand
-work silently.** Diff the output against the checked-in YAML instead, and use the flatten-and-compare
-check described in the root README to see what actually moved.
-
-The exception worth copying is `TIM.yaml`'s `CCD`/`CCU` step: `!MakeFieldArray` with `mode: Cursed`
-produces exactly the offset lists the checked-in block carries, so that piece of the cleanup at least
-survives a re-derivation.
+A transform that does not reproduce its block is usually written against a different source instance.
+`TIM.yaml` runs from `TIMA0` on MSPM0G350X, which has four capture/compare channels and neither the
+`DC` nor the `QEIERR` event. Its output cannot match `tim_v1` however the transform is written.
 
 ## Deviations from the SVD
 
 Each entry says what the SVD claims, what this repo says instead, and what the evidence is.
 
-When checking a release for unintended movement, fingerprint the *generated* Rust rather than the
-YAML — read the register offsets back out of `wrapping_add` and the field positions out of each
-accessor's `(shift, mask)`. That covers everything the generator does between IR and Rust, which
-flatten-and-compare cannot see. Run it against the **immediately preceding tag**: against an older
-one it reports the three C-series fields below moving from bit 2 to bit 0, which is a correction from
-an earlier round rather than anything in the release under test.
+When checking a release for unintended movement, fingerprint the generated Rust rather than the YAML.
+Read the register offsets back out of `wrapping_add` and the field positions out of each accessor's
+`(shift, mask)`. That covers everything the generator does between IR and Rust, and
+flatten-and-compare sees none of it.
 
-### `sysctl_c110x`, `sysctl_c1105_c1106` — three unlock-protected control bits are at bit 0
+### `sysctl_c110x`, `sysctl_c1105_c1106`: three unlock-protected control bits are at bit 0
 
 | fieldset | field |
 | --- | --- |
@@ -58,33 +45,33 @@ an earlier round rather than anything in the release under test.
 | `EXRSTPIN` | `DISABLE` |
 | `SYSSTATUSCLR` | `ALLECC` |
 
-The C-series SVD puts each of these at bit 2. That contradicts SLAU893 and every other family's
-SYSCTL, which agree on bit 0. Taking the SVD's word for it would produce a HAL whose writes to these
-three registers never take effect.
+The C-series SVD puts each of these at bit 2. SLAU893 and every other family's SYSCTL agree on bit 0.
+Taking the SVD's word for it would produce a HAL whose writes to these three registers never take
+effect.
 
-### `sysctl_l110x_l130x_l134x` — `RSTCAUSE.BOOTSW` is 13
+### `sysctl_l110x_l130x_l134x`: `RSTCAUSE.BOOTSW` is 13
 
 The SVD says 10, copied from SLAU847's field description for this SYSCTL variant. That description
 contradicts the same TRM's "Reset Causes" table, which lists 10 as reserved and 13 as the
 software-triggered BOOTRST. Every other family agrees with the table. `BOOTWWDT0` in the same enum
 had already been corrected against that table for the same reason.
 
-### `cpuss_v1` — the interrupt group's `MIS`, `ISET` and `ICLR` are 8 bits
+### `cpuss_v1`: the interrupt group's `MIS`, `ISET` and `ICLR` are 8 bits
 
 The SVD gives these three a single bit, where it gives `IMASK` and `RIS` eight. `hw_cpuss.h` masks
-all five with `0xFF`, and the group's `IIDX` enumerates `INT0` to `INT7`, so a single bit would leave
+all five with `0xFF`, and the group's `IIDX` enumerates `INT0` to `INT7`. A single bit would leave
 only interrupt 0 reachable through three of the five registers.
 
-### `gpio_v1` — the generic event masks are indexed by absolute DIO number
+### `gpio_v1`: the generic event masks are indexed by absolute DIO number
 
 The SVD bases both generic event blocks at bit 0 with sixteen bits each. `hw_gpio.h` puts
-`GEN_EVENT0`'s `DIO0` to `DIO15` at bits 0 to 15 but `GEN_EVENT1`'s `DIO16` to `DIO31` at bits **16
-to 31**. Both blocks now share the same 32-bit fieldset as `CPU_INT` and the `DOUT`/`DIN` masks, so
-one bit index means one DIO number everywhere; each event block implements only its own half.
+`GEN_EVENT0`'s `DIO0` to `DIO15` at bits 0 to 15, but `GEN_EVENT1`'s `DIO16` to `DIO31` at bits 16 to
+31. Both blocks now share the same 32-bit fieldset as `CPU_INT` and the `DOUT`/`DIN` masks, so one
+bit index means one DIO number everywhere. Each event block implements only its own half.
 
-### `tim_v1` — `CCD` and `CCU` are offset-list arrays
+### `tim_v1`: `CCD` and `CCU` are offset-list arrays
 
-Not a contradiction, but the reason a plain stride does not appear here: capture/compare channels 4
-and 5 are compare-only and sit *above* the `CCU` bits rather than next to `CCD0` to `CCD3`
-(`CCD` at bits 4-7 and 12-13, `CCU` at 8-11 and 14-15, per `hw_gptimer.h`). The arrays use chiptool's
-explicit `offsets:` list so that `ccd(n)` and `ccu(n)` still take a channel number.
+Not a contradiction. Capture/compare channels 4 and 5 are compare-only and sit above the `CCU` bits
+rather than next to `CCD0` to `CCD3` (`CCD` at bits 4-7 and 12-13, `CCU` at 8-11 and 14-15, per
+`hw_gptimer.h`). A plain stride cannot describe that, so the arrays use chiptool's explicit
+`offsets:` list, which keeps `ccd(n)` and `ccu(n)` taking a channel number.

--- a/data/registers/README.md
+++ b/data/registers/README.md
@@ -43,6 +43,13 @@ survives a re-derivation.
 
 Each entry says what the SVD claims, what this repo says instead, and what the evidence is.
 
+When checking a release for unintended movement, fingerprint the *generated* Rust rather than the
+YAML — read the register offsets back out of `wrapping_add` and the field positions out of each
+accessor's `(shift, mask)`. That covers everything the generator does between IR and Rust, which
+flatten-and-compare cannot see. Run it against the **immediately preceding tag**: against an older
+one it reports the three C-series fields below moving from bit 2 to bit 0, which is a correction from
+an earlier round rather than anything in the release under test.
+
 ### `sysctl_c110x`, `sysctl_c1105_c1106` — three unlock-protected control bits are at bit 0
 
 | fieldset | field |

--- a/data/registers/adc_v1.yaml
+++ b/data/registers/adc_v1.yaml
@@ -59,22 +59,21 @@ block/ADC:
     description: Sample Clock Frequency Range Register.
     byte_offset: 4368
     fieldset: CLKFREQ
-  - name: SCOMP0
-    description: Sample Time Compare 0 Register.
+  - name: SCOMP
+    description: Sample Time Compare Register.
+    array:
+      len: 2
+      stride: 4
     byte_offset: 4372
-    fieldset: SCOMP0
-  - name: SCOMP1
-    description: Sample Time Compare 1 Register.
-    byte_offset: 4376
-    fieldset: SCOMP1
+    fieldset: SCOMP
   - name: WCLOW
     description: Window Comparator Low Threshold Register.
     byte_offset: 4424
-    fieldset: WCLOW
+    fieldset: WC
   - name: WCHIGH
     description: Window Comparator High Threshold Register.
     byte_offset: 4432
-    fieldset: WCHIGH
+    fieldset: WC
   - name: MEMCTL
     description: Conversion Memory Control Register.
     array:
@@ -309,10 +308,9 @@ fieldset/CTL1:
     bit_size: 1
     enum: TRIGSRC
   - name: SC
-    description: Start of conversion.
+    description: Start of conversion. With SAMPMODE MANUAL the sample phase lasts as long as this bit is set, and clearing it starts the conversion phase; with AUTO, setting it triggers the timer based sample time and clearing it does nothing.
     bit_offset: 8
     bit_size: 1
-    enum: SC
   - name: CONSEQ
     description: Conversion sequence mode.
     bit_offset: 16
@@ -357,10 +355,9 @@ fieldset/CTL2:
     bit_offset: 10
     bit_size: 1
   - name: SAMPCNT
-    description: Number of ADC converted samples to be transferred on a DMA trigger.
+    description: Number of ADC converted samples to be transferred on a DMA trigger, up to 24.
     bit_offset: 11
     bit_size: 5
-    enum: SAMPCNT
   - name: STARTADD
     description: Sequencer start address. These bits select which MEMCTLx is used for single conversion or as first MEMCTL for sequence mode. The value of STARTADD is 0x00 to 0x17, corresponding to MEMRES0 to MEMRES23.
     bit_offset: 16
@@ -417,12 +414,12 @@ fieldset/EVT_MODE:
     description: Event line mode select for event corresponding to CPU_INT.
     bit_offset: 0
     bit_size: 2
-    enum: INT_CFG
+    enum: EVT_CFG
   - name: EVT1_CFG
     description: Event line mode select for event corresponding to GEN_EVENT.
     bit_offset: 2
     bit_size: 2
-    enum: EVT1_CFG
+    enum: EVT_CFG
 fieldset/FPORT:
   description: Publisher Configuration Register.
   fields:
@@ -525,15 +522,8 @@ fieldset/RSTCTL:
     bit_offset: 24
     bit_size: 8
     enum: RESET_KEY
-fieldset/SCOMP0:
-  description: Sample Time Compare 0 Register.
-  fields:
-  - name: VAL
-    description: 'Specifies the number of sample clocks. When VAL = 0 or 1, number of sample clocks = Sample clock divide value. When VAL > 1, number of sample clocks = VAL x Sample clock divide value. Note: Sample clock divide value is not the value written to SCLKDIV but the actual divide value (SCLKDIV = 2 implies divide value is 4). Example: VAL = 4, SCLKDIV = 3 implies 32 sample clock cycles.'
-    bit_offset: 0
-    bit_size: 10
-fieldset/SCOMP1:
-  description: Sample Time Compare 1 Register.
+fieldset/SCOMP:
+  description: Sample Time Compare Register.
   fields:
   - name: VAL
     description: 'Specifies the number of sample clocks. When VAL = 0 or 1, number of sample clocks = Sample clock divide value. When VAL > 1, number of sample clocks = VAL x Sample clock divide value. Note: Sample clock divide value is not the value written to SCLKDIV but the actual divide value (SCLKDIV = 2 implies divide value is 4). Example: VAL = 4, SCLKDIV = 3 implies 32 sample clock cycles.'
@@ -557,15 +547,8 @@ fieldset/STATUS:
     description: Indicates reference buffer is powered up and ready.
     bit_offset: 1
     bit_size: 1
-fieldset/WCHIGH:
-  description: Window Comparator High Threshold Register.
-  fields:
-  - name: DATA
-    description: If DF = 0, unsigned binary format has to be used. The threshold value has to be right aligned, with the MSB on the left. For 10-bits and 8-bits resolution, unused bit have to be 0s. If DF = 1, 2s-complement format has to be used. The value based on the resolution has to be left aligned with the LSB on the right. For 10-bits and 8-bits resolution, unused bit have to be 0s.
-    bit_offset: 0
-    bit_size: 16
-fieldset/WCLOW:
-  description: Window Comparator Low Threshold Register.
+fieldset/WC:
+  description: A window comparator threshold.
   fields:
   - name: DATA
     description: If DF = 0, unsigned binary format has to be used. The value based on the resolution has to be right aligned with the MSB on the left. For 10-bits and 8-bits resolution, unused bits have to be 0s. If DF = 1, 2s-complement format has to be used. The value based on the resolution has to be left aligned with the LSB on the right. For 10-bits and 8-bits resolution, unused bits have to be 0s.
@@ -795,18 +778,6 @@ enum/DMA_TRIG_IIDX_STAT:
   - name: MEMRESIFG23
     description: MEMRES23 data loaded interrupt.
     value: 32
-enum/EVT1_CFG:
-  bit_size: 2
-  variants:
-  - name: DISABLE
-    description: The interrupt or event line is disabled.
-    value: 0
-  - name: SOFTWARE
-    description: The interrupt or event line is in software mode. Software must clear the RIS.
-    value: 1
-  - name: HARDWARE
-    description: The interrupt or event line is in hardware mode. The hardware (another module) clears automatically the associated RIS flag.
-    value: 2
 enum/FRANGE:
   bit_size: 3
   variants:
@@ -852,7 +823,7 @@ enum/GEN_EVENT_IIDX_STAT:
   - name: MEMRESIFG0
     description: MEMRES0 data loaded interrupt.
     value: 9
-enum/INT_CFG:
+enum/EVT_CFG:
   bit_size: 2
   variants:
   - name: DISABLE
@@ -907,15 +878,6 @@ enum/SAMPCLK:
   - name: HFCLK
     description: 'HFCLK clock is the source of ADC sample clock. Note : HFCLK may not be available on all the devices.'
     value: 2
-enum/SAMPCNT:
-  bit_size: 5
-  variants:
-  - name: MIN
-    description: Minimum value.
-    value: 0
-  - name: MAX
-    description: Maximum value.
-    value: 24
 enum/SAMPMODE:
   bit_size: 1
   variants:
@@ -924,15 +886,6 @@ enum/SAMPMODE:
     value: 0
   - name: MANUAL
     description: Software trigger is used as sample signal.
-    value: 1
-enum/SC:
-  bit_size: 1
-  variants:
-  - name: STOP
-    description: When SAMPMODE is set to MANUAL, clearing this bit will end the sample phase and the conversion phase will start. When SAMPMODE is set to AUTO, writing 0 has no effect.
-    value: 0
-  - name: START
-    description: When SAMPMODE is set to MANUAL, setting this bit will start the sample phase. Sample phase will last as long as this bit is set. When SAMPMODE is set to AUTO, setting this bit will trigger the timer based sample time.
     value: 1
 enum/SCLKDIV:
   bit_size: 3

--- a/data/registers/beeper_v1.yaml
+++ b/data/registers/beeper_v1.yaml
@@ -1,5 +1,5 @@
 block/BEEPER:
-  description: The MSPM0C110x/MSPS003 beeper. This technically exists in the SYSCTL block, but is separated. 
+  description: 'The beeper, addressed through SYSCTL: this is one register of that block, split out so the four SYSCTL variants which have it do not each carry a copy. Present on C110x, C1105/C1106, MSPS003, H321x, L112x and L211x.'
   items:
   - name: BEEPCFG
     description: BEEPER Configuration

--- a/data/registers/beeper_v1.yaml
+++ b/data/registers/beeper_v1.yaml
@@ -12,21 +12,11 @@ fieldset/BEEPCFG:
     description: Beeper output enable
     bit_offset: 0
     bit_size: 1
-    enum: EN
   - name: FREQ
     description: Beeper Output Frequency Configuration
     bit_offset: 4
     bit_size: 2
     enum: FREQ
-enum/EN:
-  bit_size: 1
-  variants:
-  - name: DISABLE
-    description: Beeper Output Disabled
-    value: 0
-  - name: ENABLE
-    description: Beeper Output Enabled
-    value: 1
 enum/FREQ:
   bit_size: 2
   variants:

--- a/data/registers/canfd_v1.yaml
+++ b/data/registers/canfd_v1.yaml
@@ -60,95 +60,95 @@ block/CPU_INT:
     fieldset: CPU_INT
 block/ECC:
   items:
-  - name: ERR_REV
+  - name: REV
     description: MCAN Error Aggregator Revision Register.
     byte_offset: 0
     access: Read
     fieldset: ERR_REV
-  - name: ERR_VECTOR
+  - name: VECTOR
     description: MCAN ECC Vector Register.
     byte_offset: 8
     fieldset: ERR_VECTOR
-  - name: ERR_STAT
+  - name: STAT
     description: MCAN Error Misc Status.
     byte_offset: 12
     access: Read
     fieldset: ERR_STAT
-  - name: ERR_WRAP_REV
+  - name: WRAP_REV
     description: MCAN ECC Wrapper Revision Register.
     byte_offset: 16
     access: Read
     fieldset: ERR_WRAP_REV
-  - name: ERR_CTRL
+  - name: CTRL
     description: MCAN ECC Control.
     byte_offset: 20
     fieldset: ERR_CTRL
-  - name: ERR_ERR_CTRL1
+  - name: ERR_CTRL1
     description: MCAN ECC Error Control 1 Register.
     byte_offset: 24
     fieldset: ERR_ERR_CTRL1
-  - name: ERR_ERR_CTRL2
+  - name: ERR_CTRL2
     description: MCAN ECC Error Control 2 Register.
     byte_offset: 28
     fieldset: ERR_ERR_CTRL2
-  - name: ERR_ERR_STAT1
+  - name: ERR_STAT1
     description: MCAN ECC Error Status 1 Register.
     byte_offset: 32
     fieldset: ERR_ERR_STAT1
-  - name: ERR_ERR_STAT2
+  - name: ERR_STAT2
     description: MCAN ECC Error Status 2 Register.
     byte_offset: 36
     access: Read
     fieldset: ERR_ERR_STAT2
-  - name: ERR_ERR_STAT3
+  - name: ERR_STAT3
     description: MCAN ECC Error Status 3 Register.
     byte_offset: 40
     fieldset: ERR_ERR_STAT3
-  - name: ERR_SEC_EOI
+  - name: SEC_EOI
     description: MCAN Single Error Corrected End of Interrupt Register.
     byte_offset: 60
     fieldset: ERR_SEC_EOI
-  - name: ERR_SEC_STATUS
+  - name: SEC_STATUS
     description: MCAN Single Error Corrected Interrupt Status Register.
     byte_offset: 64
     fieldset: ERR_SEC_STATUS
-  - name: ERR_SEC_ENABLE_SET
+  - name: SEC_ENABLE_SET
     description: MCAN Single Error Corrected Interrupt Enable Set Register.
     byte_offset: 128
     fieldset: ERR_SEC_ENABLE_SET
-  - name: ERR_SEC_ENABLE_CLR
+  - name: SEC_ENABLE_CLR
     description: MCAN Single Error Corrected Interrupt Enable Clear Register.
     byte_offset: 192
     fieldset: ERR_SEC_ENABLE_CLR
-  - name: ERR_DED_EOI
+  - name: DED_EOI
     description: MCAN Double Error Detected End of Interrupt Register.
     byte_offset: 316
     fieldset: ERR_DED_EOI
-  - name: ERR_DED_STATUS
+  - name: DED_STATUS
     description: MCAN Double Error Detected Interrupt Status Register.
     byte_offset: 320
     fieldset: ERR_DED_STATUS
-  - name: ERR_DED_ENABLE_SET
+  - name: DED_ENABLE_SET
     description: MCAN Double Error Detected Interrupt Enable Set Register.
     byte_offset: 384
     fieldset: ERR_DED_ENABLE_SET
-  - name: ERR_DED_ENABLE_CLR
+  - name: DED_ENABLE_CLR
     description: MCAN Double Error Detected Interrupt Enable Clear Register.
     byte_offset: 448
     fieldset: ERR_DED_ENABLE_CLR
-  - name: ERR_AGGR_ENABLE_SET
+  - name: AGGR_ENABLE_SET
     description: MCAN Error Aggregator Enable Set Register.
     byte_offset: 512
     fieldset: ERR_AGGR_ENABLE_SET
-  - name: ERR_AGGR_ENABLE_CLR
+  - name: AGGR_ENABLE_CLR
     description: MCAN Error Aggregator Enable Clear Register.
     byte_offset: 516
     fieldset: ERR_AGGR_ENABLE_CLR
-  - name: ERR_AGGR_STATUS_SET
+  - name: AGGR_STATUS_SET
     description: MCAN Error Aggregator Status Set Register.
     byte_offset: 520
     fieldset: ERR_AGGR_STATUS_SET
-  - name: ERR_AGGR_STATUS_CLR
+  - name: AGGR_STATUS_CLR
     description: MCAN Error Aggregator Status Clear Register.
     byte_offset: 524
     fieldset: ERR_AGGR_STATUS_CLR
@@ -400,50 +400,50 @@ block/PROCESSORS:
     block: ECC
 block/SUBSYS:
   items:
-  - name: SUBSYS_PID
+  - name: PID
     description: MCAN Subsystem Revision Register.
     byte_offset: 0
     access: Read
     fieldset: SUBSYS_PID
-  - name: SUBSYS_CTRL
+  - name: CTRL
     description: MCAN Subsystem Control Register.
     byte_offset: 4
     fieldset: SUBSYS_CTRL
-  - name: SUBSYS_STAT
+  - name: STAT
     description: MCAN Subsystem Status Register.
     byte_offset: 8
     access: Read
     fieldset: SUBSYS_STAT
-  - name: SUBSYS_ICS
+  - name: ICS
     description: MCAN Subsystem Interrupt Clear Shadow Register.
     byte_offset: 12
     fieldset: SUBSYS_ICS
-  - name: SUBSYS_IRS
+  - name: IRS
     description: MCAN Subsystem Interrupt Raw Satus Register.
     byte_offset: 16
     fieldset: SUBSYS_IRS
-  - name: SUBSYS_IECS
+  - name: IECS
     description: MCAN Subsystem Interrupt Enable Clear Shadow Register.
     byte_offset: 20
     fieldset: SUBSYS_IECS
-  - name: SUBSYS_IE
+  - name: IE
     description: MCAN Subsystem Interrupt Enable Register.
     byte_offset: 24
     fieldset: SUBSYS_IE
-  - name: SUBSYS_IES
+  - name: IES
     description: MCAN Subsystem Interrupt Enable Status.
     byte_offset: 28
     access: Read
     fieldset: SUBSYS_IES
-  - name: SUBSYS_EOI
+  - name: EOI
     description: MCAN Subsystem End of Interrupt.
     byte_offset: 32
     fieldset: SUBSYS_EOI
-  - name: SUBSYS_EXT_TS_PRESCALER
+  - name: EXT_TS_PRESCALER
     description: MCAN Subsystem External Timestamp Prescaler 0.
     byte_offset: 36
     fieldset: SUBSYS_EXT_TS_PRESCALER
-  - name: SUBSYS_EXT_TS_UNSERVICED_INTR_CNTR
+  - name: EXT_TS_UNSERVICED_INTR_CNTR
     description: MCAN Subsystem External Timestamp Unserviced Interrupts Counter.
     byte_offset: 40
     access: Read

--- a/data/registers/canfd_v1.yaml
+++ b/data/registers/canfd_v1.yaml
@@ -78,7 +78,7 @@ block/ECC:
     description: MCAN ECC Wrapper Revision Register.
     byte_offset: 16
     access: Read
-    fieldset: ERR_WRAP_REV
+    fieldset: ERR_REV
   - name: CTRL
     description: MCAN ECC Control.
     byte_offset: 20
@@ -86,7 +86,6 @@ block/ECC:
   - name: ERR_CTRL1
     description: MCAN ECC Error Control 1 Register.
     byte_offset: 24
-    fieldset: ERR_ERR_CTRL1
   - name: ERR_CTRL2
     description: MCAN ECC Error Control 2 Register.
     byte_offset: 28
@@ -99,7 +98,6 @@ block/ECC:
     description: MCAN ECC Error Status 2 Register.
     byte_offset: 36
     access: Read
-    fieldset: ERR_ERR_STAT2
   - name: ERR_STAT3
     description: MCAN ECC Error Status 3 Register.
     byte_offset: 40
@@ -107,35 +105,35 @@ block/ECC:
   - name: SEC_EOI
     description: MCAN Single Error Corrected End of Interrupt Register.
     byte_offset: 60
-    fieldset: ERR_SEC_EOI
+    fieldset: ERR_EOI
   - name: SEC_STATUS
     description: MCAN Single Error Corrected Interrupt Status Register.
     byte_offset: 64
-    fieldset: ERR_SEC_STATUS
+    fieldset: ERR_STATUS
   - name: SEC_ENABLE_SET
     description: MCAN Single Error Corrected Interrupt Enable Set Register.
     byte_offset: 128
-    fieldset: ERR_SEC_ENABLE_SET
+    fieldset: ERR_ENABLE_SET
   - name: SEC_ENABLE_CLR
     description: MCAN Single Error Corrected Interrupt Enable Clear Register.
     byte_offset: 192
-    fieldset: ERR_SEC_ENABLE_CLR
+    fieldset: ERR_ENABLE_CLR
   - name: DED_EOI
     description: MCAN Double Error Detected End of Interrupt Register.
     byte_offset: 316
-    fieldset: ERR_DED_EOI
+    fieldset: ERR_EOI
   - name: DED_STATUS
     description: MCAN Double Error Detected Interrupt Status Register.
     byte_offset: 320
-    fieldset: ERR_DED_STATUS
+    fieldset: ERR_STATUS
   - name: DED_ENABLE_SET
     description: MCAN Double Error Detected Interrupt Enable Set Register.
     byte_offset: 384
-    fieldset: ERR_DED_ENABLE_SET
+    fieldset: ERR_ENABLE_SET
   - name: DED_ENABLE_CLR
     description: MCAN Double Error Detected Interrupt Enable Clear Register.
     byte_offset: 448
-    fieldset: ERR_DED_ENABLE_CLR
+    fieldset: ERR_ENABLE_CLR
   - name: AGGR_ENABLE_SET
     description: MCAN Error Aggregator Enable Set Register.
     byte_offset: 512
@@ -147,11 +145,11 @@ block/ECC:
   - name: AGGR_STATUS_SET
     description: MCAN Error Aggregator Status Set Register.
     byte_offset: 520
-    fieldset: ERR_AGGR_STATUS_SET
+    fieldset: ERR_AGGR_STATUS
   - name: AGGR_STATUS_CLR
     description: MCAN Error Aggregator Status Clear Register.
     byte_offset: 524
-    fieldset: ERR_AGGR_STATUS_CLR
+    fieldset: ERR_AGGR_STATUS
 block/MCAN:
   items:
   - name: CREL
@@ -163,7 +161,6 @@ block/MCAN:
     description: MCAN Endian Register.
     byte_offset: 4
     access: Read
-    fieldset: ENDN
   - name: DBTP
     description: MCAN Data Bit Timing and Prescaler Register.
     byte_offset: 12
@@ -251,13 +248,12 @@ block/MCAN:
     byte_offset: 148
     access: Read
     fieldset: HPMS
-  - name: NDAT1
-    description: MCAN New Data 1.
+  - name: NDAT
+    description: 'MCAN New Data. Index 0 covers message buffers 0 to 31 and index 1 buffers 32 to 63.'
+    array:
+      len: 2
+      stride: 4
     byte_offset: 152
-    fieldset: NDAT
-  - name: NDAT2
-    description: MCAN New Data 2.
-    byte_offset: 156
     fieldset: NDAT
   - name: RXF0C
     description: MCAN Rx FIFO 0 Configuration.
@@ -417,24 +413,24 @@ block/SUBSYS:
   - name: ICS
     description: MCAN Subsystem Interrupt Clear Shadow Register.
     byte_offset: 12
-    fieldset: SUBSYS_ICS
+    fieldset: SUBSYS_INT
   - name: IRS
     description: MCAN Subsystem Interrupt Raw Satus Register.
     byte_offset: 16
-    fieldset: SUBSYS_IRS
+    fieldset: SUBSYS_INT
   - name: IECS
     description: MCAN Subsystem Interrupt Enable Clear Shadow Register.
     byte_offset: 20
-    fieldset: SUBSYS_IECS
+    fieldset: SUBSYS_INT
   - name: IE
     description: MCAN Subsystem Interrupt Enable Register.
     byte_offset: 24
-    fieldset: SUBSYS_IE
+    fieldset: SUBSYS_INT
   - name: IES
     description: MCAN Subsystem Interrupt Enable Status.
     byte_offset: 28
     access: Read
-    fieldset: SUBSYS_IES
+    fieldset: SUBSYS_INT
   - name: EOI
     description: MCAN Subsystem End of Interrupt.
     byte_offset: 32
@@ -524,14 +520,13 @@ fieldset/CCCR:
 fieldset/CPU_INT:
   description: Interrupt clear.
   fields:
-  - name: INTL0
-    description: Clear MCAN Interrupt Line 0.
+  - name: INTL
+    description: The MCAN interrupt line.
     bit_offset: 0
     bit_size: 1
-  - name: INTL1
-    description: Clear MCAN Interrupt Line 1.
-    bit_offset: 1
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: SEC
     description: Clear Message RAM SEC interrupt.
     bit_offset: 2
@@ -637,9 +632,6 @@ fieldset/ECR:
     description: 'CAN Error Logging. The counter is incremented each time when a CAN protocol error causes the Transmit Error Counter or the Receive Error Counter to be incremented. It is reset by read access to CEL. The counter stops at 0xFF; the next increment of TEC or REC sets interrupt flag IR.ELO. Note: When CCCR.ASM is set, the CAN protocol controller does not increment TEC and REC when a CAN protocol error is detected, but CEL is still incremented.'
     bit_offset: 16
     bit_size: 8
-fieldset/ENDN:
-  description: MCAN Endian Register.
-  fields: []
 fieldset/ERR_AGGR_ENABLE_CLR:
   description: MCAN Error Aggregator Enable Clear Register.
   fields:
@@ -662,19 +654,8 @@ fieldset/ERR_AGGR_ENABLE_SET:
     description: Write 1 to enable timeout errors. Reads return the corresponding enable bit's current value.
     bit_offset: 1
     bit_size: 1
-fieldset/ERR_AGGR_STATUS_CLR:
-  description: MCAN Error Aggregator Status Clear Register.
-  fields:
-  - name: AGGR_PARITY_ERR
-    description: Aggregator Parity Error Status 2-bit saturating counter of the number of parity errors that have occurred since last cleared. 0 No parity errors have occurred 1 One parity error has occurred 2 Two parity errors have occurred 3 Three parity errors have occurred A write of a non-zero value to this bit field decrements it by the value provided.
-    bit_offset: 0
-    bit_size: 2
-  - name: SVBUS_TIMEOUT
-    description: Aggregator Serial VBUS Timeout Error Status 2-bit saturating counter of the number of SVBUS timeout errors that have occurred since last cleared. 0 No timeout errors have occurred 1 One timeout error has occurred 2 Two timeout errors have occurred 3 Three timeout errors have occurred A write of a non-zero value to this bit field decrements it by the value provided.
-    bit_offset: 2
-    bit_size: 2
-fieldset/ERR_AGGR_STATUS_SET:
-  description: MCAN Error Aggregator Status Set Register.
+fieldset/ERR_AGGR_STATUS:
+  description: MCAN ECC aggregator status.
   fields:
   - name: AGGR_PARITY_ERR
     description: Aggregator Parity Error Status 2-bit saturating counter of the number of parity errors that have occurred since last cleared. 0 No parity errors have occurred 1 One parity error has occurred 2 Two parity errors have occurred 3 Three parity errors have occurred A write of a non-zero value to this bit field increments it by the value provided.
@@ -719,37 +700,6 @@ fieldset/ERR_CTRL:
     description: Enables Serial VBUS timeout mechanism.
     bit_offset: 8
     bit_size: 1
-fieldset/ERR_DED_ENABLE_CLR:
-  description: MCAN Double Error Detected Interrupt Enable Clear Register.
-  fields:
-  - name: MSGMEM_ENABLE_CLR
-    description: Message RAM DED Interrupt Pending Enable Clear. Writing a 1 to this bit disables the Message RAM DED error interrupts. Writing a 0 has no effect. Reads return the corresponding enable bit's current value.
-    bit_offset: 0
-    bit_size: 1
-fieldset/ERR_DED_ENABLE_SET:
-  description: MCAN Double Error Detected Interrupt Enable Set Register.
-  fields:
-  - name: MSGMEM_ENABLE_SET
-    description: Message RAM DED Interrupt Pending Enable Set. Writing a 1 to this bit enables the Message RAM DED error interrupts. Writing a 0 has no effect. Reads return the corresponding enable bit's current value.
-    bit_offset: 0
-    bit_size: 1
-fieldset/ERR_DED_EOI:
-  description: MCAN Double Error Detected End of Interrupt Register.
-  fields:
-  - name: EOI_WR
-    description: Write to this register indicates that software has acknowledged the pending interrupt and the next interrupt can be sent to the host. Note that a write to the MCANERR_ERR_STAT1.CLR_ECC_DED goes through the SVBUS and has a delayed completion. To avoid an additional interrupt, read the MCANERR_ERR_STAT1 register back prior to writing to this bit field.
-    bit_offset: 0
-    bit_size: 1
-fieldset/ERR_DED_STATUS:
-  description: MCAN Double Error Detected Interrupt Status Register.
-  fields:
-  - name: MSGMEM_PEND
-    description: Message RAM DED Interrupt Pending 0 No DED interrupt is pending 1 DED interrupt is pending.
-    bit_offset: 0
-    bit_size: 1
-fieldset/ERR_ERR_CTRL1:
-  description: MCAN ECC Error Control 1 Register.
-  fields: []
 fieldset/ERR_ERR_CTRL2:
   description: MCAN ECC Error Control 2 Register.
   fields:
@@ -800,9 +750,6 @@ fieldset/ERR_ERR_STAT1:
     description: ECC Error Bit Position. Indicates the bit position in the RAM data that is in error on an SEC error. Only valid on an SEC error. 0 Bit 0 is in error 1 Bit 1 is in error 2 Bit 2 is in error 3 Bit 3 is in error ... 31 Bit 31 is in error >32 Invalid.
     bit_offset: 16
     bit_size: 16
-fieldset/ERR_ERR_STAT2:
-  description: MCAN ECC Error Status 2 Register.
-  fields: []
 fieldset/ERR_ERR_STAT3:
   description: MCAN ECC Error Status 3 Register.
   fields:
@@ -819,7 +766,7 @@ fieldset/ERR_ERR_STAT3:
     bit_offset: 9
     bit_size: 1
 fieldset/ERR_REV:
-  description: MCAN Error Aggregator Revision Register.
+  description: Revision of the ECC block or of its wrapper.
   fields:
   - name: REVMIN
     description: Minor Revision of the Error Aggregator.
@@ -837,29 +784,29 @@ fieldset/ERR_REV:
     description: PID Register Scheme.
     bit_offset: 30
     bit_size: 2
-fieldset/ERR_SEC_ENABLE_CLR:
-  description: MCAN Single Error Corrected Interrupt Enable Clear Register.
+fieldset/ERR_ENABLE_CLR:
+  description: Disable the message memory error interrupt.
   fields:
   - name: MSGMEM_ENABLE_CLR
     description: Message RAM SEC Interrupt Pending Enable Clear. Writing a 1 to this bit disables the Message RAM SEC error interrupts. Writing a 0 has no effect. Reads return the corresponding enable bit's current value.
     bit_offset: 0
     bit_size: 1
-fieldset/ERR_SEC_ENABLE_SET:
-  description: MCAN Single Error Corrected Interrupt Enable Set Register.
+fieldset/ERR_ENABLE_SET:
+  description: Enable the message memory error interrupt.
   fields:
   - name: MSGMEM_ENABLE_SET
     description: Message RAM SEC Interrupt Pending Enable Set. Writing a 1 to this bit enables the Message RAM SEC error interrupts. Writing a 0 has no effect. Reads return the corresponding enable bit's current value.
     bit_offset: 0
     bit_size: 1
-fieldset/ERR_SEC_EOI:
-  description: MCAN Single Error Corrected End of Interrupt Register.
+fieldset/ERR_EOI:
+  description: End of interrupt for a message memory error.
   fields:
   - name: EOI_WR
     description: Write to this register indicates that software has acknowledged the pending interrupt and the next interrupt can be sent to the host. Note that a write to the MCANERR_ERR_STAT1.CLR_ECC_SEC goes through the SVBUS and has a delayed completion. To avoid an additional interrupt, read the MCANERR_ERR_STAT1 register back prior to writing to this bit field.
     bit_offset: 0
     bit_size: 1
-fieldset/ERR_SEC_STATUS:
-  description: MCAN Single Error Corrected Interrupt Status Register.
+fieldset/ERR_STATUS:
+  description: Pending status of a message memory error.
   fields:
   - name: MSGMEM_PEND
     description: Message RAM SEC Interrupt Pending 0 No SEC interrupt is pending 1 SEC interrupt is pending.
@@ -891,25 +838,6 @@ fieldset/ERR_VECTOR:
     description: Read Completion Flag.
     bit_offset: 24
     bit_size: 1
-fieldset/ERR_WRAP_REV:
-  description: MCAN ECC Wrapper Revision Register.
-  fields:
-  - name: REVMIN
-    description: Minor Revision of the Error Aggregator.
-    bit_offset: 0
-    bit_size: 6
-  - name: REVMAJ
-    description: Major Revision of the Error Aggregator.
-    bit_offset: 8
-    bit_size: 3
-  - name: MODULE_ID
-    description: Module Identification Number.
-    bit_offset: 16
-    bit_size: 12
-  - name: SCHEME
-    description: PID Register Scheme.
-    bit_offset: 30
-    bit_size: 2
 fieldset/EVT_MODE:
   description: Event Mode.
   fields:
@@ -1090,14 +1018,13 @@ fieldset/IIDX:
 fieldset/ILE:
   description: MCAN Interrupt Line Enable.
   fields:
-  - name: EINT0
-    description: Enable Interrupt Line 0 0 Interrupt Line 0 is disabled 1 Interrupt Line 0 is enabled.
+  - name: EINT
+    description: Enable the MCAN interrupt line.
     bit_offset: 0
     bit_size: 1
-  - name: EINT1
-    description: Enable Interrupt Line 1 0 Interrupt Line 1 is disabled 1 Interrupt Line 1 is enabled.
-    bit_offset: 1
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
 fieldset/ILS:
   description: MCAN Interrupt Line Select.
   fields:
@@ -1682,39 +1609,11 @@ fieldset/SUBSYS_EXT_TS_UNSERVICED_INTR_CNTR:
     description: External Timestamp Counter Unserviced Rollover Interrupts. If this value is > 1, an MCANSS_EOI write of '1' to bit 0 will issue another interrupt. The status of this bit field is affected by the MCANSS_IRS.EXT_TS_CNTR_OVFL bit field.
     bit_offset: 0
     bit_size: 5
-fieldset/SUBSYS_ICS:
-  description: MCAN Subsystem Interrupt Clear Shadow Register.
-  fields:
-  - name: EXT_TS_CNTR_OVFL
-    description: External Timestamp Counter Overflow Interrupt Status Clear. Reads always return a 0. 0 Write of '0' has no effect 1 Write of '1' clears the MCANSS_IRS.EXT_TS_CNTR_OVFL bit.
-    bit_offset: 0
-    bit_size: 1
-fieldset/SUBSYS_IE:
-  description: MCAN Subsystem Interrupt Enable Register.
+fieldset/SUBSYS_INT:
+  description: Subsystem interrupt, one bit per source.
   fields:
   - name: EXT_TS_CNTR_OVFL
     description: External Timestamp Counter Overflow Interrupt Enable. A write of '0' has no effect. A write of '1' sets the MCANSS_IES.EXT_TS_CNTR_OVFL bit.
-    bit_offset: 0
-    bit_size: 1
-fieldset/SUBSYS_IECS:
-  description: MCAN Subsystem Interrupt Enable Clear Shadow Register.
-  fields:
-  - name: EXT_TS_CNTR_OVFL
-    description: External Timestamp Counter Overflow Interrupt Enable Clear. Reads always return a 0. 0 Write of '0' has no effect 1 Write of '1' clears the MCANSS_IES.EXT_TS_CNTR_OVFL bit.
-    bit_offset: 0
-    bit_size: 1
-fieldset/SUBSYS_IES:
-  description: MCAN Subsystem Interrupt Enable Status.
-  fields:
-  - name: EXT_TS_CNTR_OVFL
-    description: External Timestamp Counter Overflow Interrupt Enable Status. To set, use the CANSS_IE.EXT_TS_CNTR_OVFL bit. To clear, use the MCANSS_IECS.EXT_TS_CNTR_OVFL bit. 0 External timestamp counter overflow interrupt is not enabled 1 External timestamp counter overflow interrupt is enabled.
-    bit_offset: 0
-    bit_size: 1
-fieldset/SUBSYS_IRS:
-  description: MCAN Subsystem Interrupt Raw Satus Register.
-  fields:
-  - name: EXT_TS_CNTR_OVFL
-    description: External Timestamp Counter Overflow Interrupt Status. This bit is set by HW or by a SW write of '1'. To clear, use the MCANSS_ICS.EXT_TS_CNTR_OVFL bit. 0 External timestamp counter has not overflowed 1 External timestamp counter has overflowed When this bit is set to '1' by HW or SW, the MCANSS_EXT_TS_UNSERVICED_INTR_CNTR.EXT_TS_INTR_CNTR bit field will increment by 1.
     bit_offset: 0
     bit_size: 1
 fieldset/SUBSYS_PID:

--- a/data/registers/comp_dacout.yaml
+++ b/data/registers/comp_dacout.yaml
@@ -1,0 +1,565 @@
+block/COMP:
+  description: PERIPHERALREGION.
+  items:
+  - name: FSUB
+    description: Subscriber Configuration Register.
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 1024
+    fieldset: FPORT
+  - name: FPUB
+    description: Publisher Configuration Register.
+    byte_offset: 1092
+    fieldset: FPORT
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: GEN_EVENT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4176
+    block: GEN_EVENT
+  - name: EVT_MODE
+    description: Event Mode.
+    byte_offset: 4320
+    access: Read
+    fieldset: EVT_MODE
+  - name: DESC
+    description: Module Description.
+    byte_offset: 4348
+    access: Read
+    fieldset: DESC
+  - name: CTL0
+    description: Control 0.
+    byte_offset: 4352
+    fieldset: CTL0
+  - name: CTL1
+    description: Control 1.
+    byte_offset: 4356
+    fieldset: CTL1
+  - name: CTL2
+    description: Control 2.
+    byte_offset: 4360
+    fieldset: CTL2
+  - name: CTL3
+    description: Control 3.
+    byte_offset: 4364
+    fieldset: CTL3
+  - name: STAT
+    description: Status.
+    byte_offset: 4384
+    access: Read
+    fieldset: STAT
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/GEN_EVENT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: CLKCFG
+    description: Peripheral Clock Configuration Register.
+    byte_offset: 8
+    fieldset: CLKCFG
+  - name: GPRCM_STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+fieldset/CLKCFG:
+  description: Peripheral Clock Configuration Register.
+  fields:
+  - name: BLOCKASYNC
+    description: Async Clock Request is blocked from starting SYSOSC or forcing bus clock to 32MHz.
+    bit_offset: 8
+    bit_size: 1
+  - name: KEY
+    description: KEY to Allow State Change A9h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: CLKCFG_KEY
+fieldset/CTL0:
+  description: Control 0.
+  fields:
+  - name: IPSEL
+    description: Channel input selected for the positive terminal of the comparator if IPEN is set to 1.
+    bit_offset: 0
+    bit_size: 3
+  - name: IPEN
+    description: Channel input enable for the positive terminal of the comparator.
+    bit_offset: 15
+    bit_size: 1
+  - name: IMSEL
+    description: Channel input selected for the negative terminal of the comparator if IMEN is set to 1.
+    bit_offset: 16
+    bit_size: 3
+  - name: IMEN
+    description: Channel input enable for the negative terminal of the comparator.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CTL1:
+  description: Control 1.
+  fields:
+  - name: ENABLE
+    description: This bit turns on the comparator. When the comparator is turned off it consumes no power.
+    bit_offset: 0
+    bit_size: 1
+  - name: MODE
+    description: This bit selects the comparator operating mode.
+    bit_offset: 1
+    bit_size: 1
+    enum: MODE
+  - name: EXCH
+    description: This bit exchanges the comparator inputs and inverts the comparator output.
+    bit_offset: 2
+    bit_size: 1
+  - name: SHORT
+    description: This bit shorts the positive and negative input terminals of the comparator.
+    bit_offset: 3
+    bit_size: 1
+  - name: IES
+    description: This bit selected the interrupt edge for COMPIFG and COMPINVIFG.
+    bit_offset: 4
+    bit_size: 1
+    enum: IES
+  - name: HYST
+    description: These bits select the hysteresis setting of the comparator.
+    bit_offset: 5
+    bit_size: 2
+    enum: HYST
+  - name: OUTPOL
+    description: This bit selects the comparator output polarity.
+    bit_offset: 7
+    bit_size: 1
+    enum: OUTPOL
+  - name: FLTEN
+    description: This bit enables the analog filter at comparator output.
+    bit_offset: 8
+    bit_size: 1
+  - name: FLTDLY
+    description: These bits select the comparator output filter delay. See the device-specific data sheet for specific values on comparator propagation delay for different filter delay settings.
+    bit_offset: 9
+    bit_size: 2
+    enum: FLTDLY
+  - name: DACOUTEN
+    description: This bit enables DAC8 output to be connected to the pin.
+    bit_offset: 11
+    bit_size: 1
+  - name: WINCOMPEN
+    description: This bit enables window comparator operation of comparator.
+    bit_offset: 12
+    bit_size: 1
+fieldset/CTL2:
+  description: Control 2.
+  fields:
+  - name: REFMODE
+    description: This bit requests ULP_REF bandgap operation in fast mode(static) or low power mode (sampled). The local reference buffer and 8-bit DAC inside comparator module are also configured accordingly. Fast mode operation offers higher accuracy but consumes higher current. Low power operation consumes lower current but with relaxed reference voltage accuracy. Comparator requests for reference voltage from ULP_REF only when REFLVL > 0.
+    bit_offset: 0
+    bit_size: 1
+    enum: REFMODE
+  - name: REFSRC
+    description: These bits select the reference source for the comparator.
+    bit_offset: 3
+    bit_size: 3
+    enum: REFSRC
+  - name: REFSEL
+    description: This bit selects if the selected reference voltage is applied to positive or negative terminal of the comparator.
+    bit_offset: 7
+    bit_size: 1
+    enum: REFSEL
+  - name: BLANKSRC
+    description: These bits select the blanking source for the comparator.
+    bit_offset: 8
+    bit_size: 3
+    enum: BLANKSRC
+  - name: DACCTL
+    description: This bit determines if the comparator output or DACSW bit controls the selection between DACCODE0 and DACCODE1.
+    bit_offset: 16
+    bit_size: 1
+    enum: DACCTL
+  - name: DACSW
+    description: This bit selects between DACCODE0 and DACCODE1 to 8-bit DAC when DACCTL bit is 1.
+    bit_offset: 17
+    bit_size: 1
+    enum: DACSW
+  - name: SAMPMODE
+    description: Enable sampled mode of comparator.
+    bit_offset: 24
+    bit_size: 1
+fieldset/CTL3:
+  description: Control 3.
+  fields:
+  - name: DACCODE
+    description: The two 8-bit DAC codes; DACCTL and DACSW select which one drives the DAC. When the code is 0x0 the DAC output is the selected reference voltage x 1/256 V, and when it is 0xFF, x 255/256 V.
+    bit_offset: 0
+    bit_size: 8
+    array:
+      len: 2
+      stride: 16
+fieldset/DESC:
+  description: Module Description.
+  fields:
+  - name: MINREV
+    description: Minor rev of the IP.
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major rev of the IP.
+    bit_offset: 4
+    bit_size: 4
+  - name: FEATUREVER
+    description: Feature Set for the module *instance*.
+    bit_offset: 12
+    bit_size: 4
+  - name: MODULEID
+    description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
+    bit_offset: 16
+    bit_size: 16
+fieldset/EVT_MODE:
+  description: Event Mode.
+  fields:
+  - name: CPU
+    description: Event line mode select for event corresponding to CPU_INT.
+    bit_offset: 0
+    bit_size: 2
+    enum: INT_CFG
+  - name: GEN_EVENT
+    description: Event line mode select for event corresponding to GEN_EVENT.
+    bit_offset: 2
+    bit_size: 2
+    enum: INT_CFG
+fieldset/FPORT:
+  description: Event subscriber/publisher channel selection.
+  fields:
+  - name: CHANID
+    description: 0 = disconnected. 1-15 = connected to channelID = CHANID.
+    bit_offset: 0
+    bit_size: 4
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    # Three bits, not the two every TI source states: the SVDs, hw_comp.h and the TRMs all mask
+    # STAT 0x3 while their own value lists reach 4h (OUTRDYIFG). Sibling IPs size it properly
+    # (WWDT 0x1F, ADC 0x3FF), so the 0x3 is a defect in the COMP IP description alone.
+    description: Interrupt index status.
+    bit_offset: 0
+    bit_size: 3
+    enum: IIDX_STAT
+fieldset/INT:
+  description: Interrupt.
+  fields:
+  - name: COMPIFG
+    description: Masks COMPIFG.
+    bit_offset: 1
+    bit_size: 1
+  - name: COMPINVIFG
+    description: Masks COMPINVIFG.
+    bit_offset: 2
+    bit_size: 1
+  - name: OUTRDYIFG
+    description: Masks OUTRDYIFG.
+    bit_offset: 3
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+fieldset/STAT:
+  description: Status.
+  fields:
+  - name: OUT
+    description: This bit reflects the value of the comparator output. Writing to this bit has no effect on the comparator output.
+    bit_offset: 0
+    bit_size: 1
+enum/BLANKSRC:
+  bit_size: 3
+  variants:
+  - name: DISABLE
+    description: Blanking source disabled.
+    value: 0
+  - name: BLANKSRC1
+    description: Select Blanking Source 1.
+    value: 1
+  - name: BLANKSRC2
+    description: Select Blanking Source 2.
+    value: 2
+  - name: BLANKSRC3
+    description: Select Blanking Source 3.
+    value: 3
+  - name: BLANKSRC4
+    description: Select Blanking Source 4.
+    value: 4
+  - name: BLANKSRC5
+    description: Select Blanking Source 5.
+    value: 5
+  - name: BLANKSRC6
+    description: Select Blanking Source 6.
+    value: 6
+enum/CLKCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 169
+enum/DACCTL:
+  bit_size: 1
+  variants:
+  - name: COMPOUT_SEL
+    description: Comparator output controls selection between DACCODE0 and DACCODE1.
+    value: 0
+  - name: DACSW_SEL
+    description: DACSW bit controls selection between DACCODE0 and DACCODE1.
+    value: 1
+enum/DACSW:
+  bit_size: 1
+  variants:
+  - name: DACCODE0_SEL
+    description: DACCODE0 selected for 8-bit DAC.
+    value: 0
+  - name: DACCODE1_SEL
+    description: DACCODE1 selected for 8-bit DAC.
+    value: 1
+enum/FLTDLY:
+  bit_size: 2
+  variants:
+  - name: DLY_0
+    description: Typical filter delay of 70 ns.
+    value: 0
+  - name: DLY_1
+    description: Typical filter delay of 500 ns.
+    value: 1
+  - name: DLY_2
+    description: Typical filter delay of 1200 ns.
+    value: 2
+  - name: DLY_3
+    description: Typical filter delay of 2700 ns.
+    value: 3
+enum/HYST:
+  bit_size: 2
+  variants:
+  - name: NO_HYS
+    description: No hysteresis.
+    value: 0
+  - name: LOW_HYS
+    description: Low hysteresis, typical 10mV.
+    value: 1
+  - name: MED_HYS
+    description: Medium hysteresis, typical 20mV.
+    value: 2
+  - name: HIGH_HYS
+    description: High hysteresis, typical 30mV.
+    value: 3
+enum/IES:
+  bit_size: 1
+  variants:
+  - name: RISING
+    description: Rising edge sets COMPIFG and falling edge sets COMPINVIFG.
+    value: 0
+  - name: FALLING
+    description: Falling edge sets COMPIFG and rising edge sets COMPINVIFG.
+    value: 1
+enum/IIDX_STAT:
+  bit_size: 3
+  variants:
+  - name: NO_INTR
+    description: No pending interrupt.
+    value: 0
+  - name: COMPIFG
+    description: Comparator output interrupt.
+    value: 2
+  - name: COMPINVIFG
+    description: Comparator output inverted interrupt.
+    value: 3
+  - name: OUTRDYIFG
+    description: Comparator output ready interrupt.
+    value: 4
+enum/INT_CFG:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: The interrupt or event line is disabled.
+    value: 0
+  - name: SOFTWARE
+    description: The interrupt or event line is in software mode. Software must clear the RIS.
+    value: 1
+  - name: HARDWARE
+    description: The interrupt or event line is in hardware mode. The hardware (another module) clears automatically the associated RIS flag.
+    value: 2
+enum/MODE:
+  bit_size: 1
+  variants:
+  - name: FAST
+    description: Comparator is in fast mode.
+    value: 0
+  - name: ULP
+    description: Comparator is in ultra-low power mode.
+    value: 1
+enum/OUTPOL:
+  bit_size: 1
+  variants:
+  - name: NON_INV
+    description: Comparator output is non-inverted.
+    value: 0
+  - name: INV
+    description: Comparator output is inverted.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/REFMODE:
+  bit_size: 1
+  variants:
+  - name: STATIC
+    description: ULP_REF bandgap, local reference buffer and 8-bit DAC inside comparator operate in static mode.
+    value: 0
+  - name: SAMPLED
+    description: ULP_REF bandgap, local reference buffer and 8-bit DAC inside comparator operate in sampled mode.
+    value: 1
+enum/REFSEL:
+  bit_size: 1
+  variants:
+  - name: POSITIVE
+    description: If EXCH bit is 0, the selected reference is applied to positive terminal. If EXCH bit is 1, the selected reference is applied to negative terminal.
+    value: 0
+  - name: NEGATIVE
+    description: If EXCH bit is 0, the selected reference is applied to negative terminal. If EXCH bit is 1, the selected reference is applied to positive terminal.
+    value: 1
+enum/REFSRC:
+  bit_size: 3
+  variants:
+  - name: OFF
+    description: Reference voltage generator is disabled (local reference buffer as well as DAC).
+    value: 0
+  - name: VDDA_DAC
+    description: VDDA selected as the reference source to DAC and DAC output applied as reference to comparator.
+    value: 1
+  - name: VREF_DAC
+    description: VREF selected as reference to DAC and DAC output applied as reference to comparator.
+    value: 2
+  - name: VREF
+    description: In devices where internal VREF is buffered and hookedup to extrernal VREF pin, VREF applied as reference to comparator. DAC is switched off.
+    value: 3
+  - name: VDDA
+    description: VDDA is used as comparator reference.
+    value: 5
+  - name: INTVREF_DAC
+    description: Internal reference selected as the reference source to DAC and DAC output applied as reference to comparator.
+    value: 6
+  - name: INTVREF
+    description: Internal VREF is used as the source of comparator. Not all devices will have this option.
+    value: 7
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/comp_v1.yaml
+++ b/data/registers/comp_v1.yaml
@@ -1,0 +1,561 @@
+block/COMP:
+  description: PERIPHERALREGION.
+  items:
+  - name: FSUB
+    description: Subscriber Configuration Register.
+    array:
+      len: 2
+      stride: 4
+    byte_offset: 1024
+    fieldset: FPORT
+  - name: FPUB
+    description: Publisher Configuration Register.
+    byte_offset: 1092
+    fieldset: FPORT
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: GEN_EVENT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4176
+    block: GEN_EVENT
+  - name: EVT_MODE
+    description: Event Mode.
+    byte_offset: 4320
+    access: Read
+    fieldset: EVT_MODE
+  - name: DESC
+    description: Module Description.
+    byte_offset: 4348
+    access: Read
+    fieldset: DESC
+  - name: CTL0
+    description: Control 0.
+    byte_offset: 4352
+    fieldset: CTL0
+  - name: CTL1
+    description: Control 1.
+    byte_offset: 4356
+    fieldset: CTL1
+  - name: CTL2
+    description: Control 2.
+    byte_offset: 4360
+    fieldset: CTL2
+  - name: CTL3
+    description: Control 3.
+    byte_offset: 4364
+    fieldset: CTL3
+  - name: STAT
+    description: Status.
+    byte_offset: 4384
+    access: Read
+    fieldset: STAT
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/GEN_EVENT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: CLKCFG
+    description: Peripheral Clock Configuration Register.
+    byte_offset: 8
+    fieldset: CLKCFG
+  - name: GPRCM_STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+fieldset/CLKCFG:
+  description: Peripheral Clock Configuration Register.
+  fields:
+  - name: BLOCKASYNC
+    description: Async Clock Request is blocked from starting SYSOSC or forcing bus clock to 32MHz.
+    bit_offset: 8
+    bit_size: 1
+  - name: KEY
+    description: KEY to Allow State Change A9h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: CLKCFG_KEY
+fieldset/CTL0:
+  description: Control 0.
+  fields:
+  - name: IPSEL
+    description: Channel input selected for the positive terminal of the comparator if IPEN is set to 1.
+    bit_offset: 0
+    bit_size: 3
+  - name: IPEN
+    description: Channel input enable for the positive terminal of the comparator.
+    bit_offset: 15
+    bit_size: 1
+  - name: IMSEL
+    description: Channel input selected for the negative terminal of the comparator if IMEN is set to 1.
+    bit_offset: 16
+    bit_size: 3
+  - name: IMEN
+    description: Channel input enable for the negative terminal of the comparator.
+    bit_offset: 31
+    bit_size: 1
+fieldset/CTL1:
+  description: Control 1.
+  fields:
+  - name: ENABLE
+    description: This bit turns on the comparator. When the comparator is turned off it consumes no power.
+    bit_offset: 0
+    bit_size: 1
+  - name: MODE
+    description: This bit selects the comparator operating mode.
+    bit_offset: 1
+    bit_size: 1
+    enum: MODE
+  - name: EXCH
+    description: This bit exchanges the comparator inputs and inverts the comparator output.
+    bit_offset: 2
+    bit_size: 1
+  - name: SHORT
+    description: This bit shorts the positive and negative input terminals of the comparator.
+    bit_offset: 3
+    bit_size: 1
+  - name: IES
+    description: This bit selected the interrupt edge for COMPIFG and COMPINVIFG.
+    bit_offset: 4
+    bit_size: 1
+    enum: IES
+  - name: HYST
+    description: These bits select the hysteresis setting of the comparator.
+    bit_offset: 5
+    bit_size: 2
+    enum: HYST
+  - name: OUTPOL
+    description: This bit selects the comparator output polarity.
+    bit_offset: 7
+    bit_size: 1
+    enum: OUTPOL
+  - name: FLTEN
+    description: This bit enables the analog filter at comparator output.
+    bit_offset: 8
+    bit_size: 1
+  - name: FLTDLY
+    description: These bits select the comparator output filter delay. See the device-specific data sheet for specific values on comparator propagation delay for different filter delay settings.
+    bit_offset: 9
+    bit_size: 2
+    enum: FLTDLY
+  - name: WINCOMPEN
+    description: This bit enables window comparator operation of comparator.
+    bit_offset: 12
+    bit_size: 1
+fieldset/CTL2:
+  description: Control 2.
+  fields:
+  - name: REFMODE
+    description: This bit requests ULP_REF bandgap operation in fast mode(static) or low power mode (sampled). The local reference buffer and 8-bit DAC inside comparator module are also configured accordingly. Fast mode operation offers higher accuracy but consumes higher current. Low power operation consumes lower current but with relaxed reference voltage accuracy. Comparator requests for reference voltage from ULP_REF only when REFLVL > 0.
+    bit_offset: 0
+    bit_size: 1
+    enum: REFMODE
+  - name: REFSRC
+    description: These bits select the reference source for the comparator.
+    bit_offset: 3
+    bit_size: 3
+    enum: REFSRC
+  - name: REFSEL
+    description: This bit selects if the selected reference voltage is applied to positive or negative terminal of the comparator.
+    bit_offset: 7
+    bit_size: 1
+    enum: REFSEL
+  - name: BLANKSRC
+    description: These bits select the blanking source for the comparator.
+    bit_offset: 8
+    bit_size: 3
+    enum: BLANKSRC
+  - name: DACCTL
+    description: This bit determines if the comparator output or DACSW bit controls the selection between DACCODE0 and DACCODE1.
+    bit_offset: 16
+    bit_size: 1
+    enum: DACCTL
+  - name: DACSW
+    description: This bit selects between DACCODE0 and DACCODE1 to 8-bit DAC when DACCTL bit is 1.
+    bit_offset: 17
+    bit_size: 1
+    enum: DACSW
+  - name: SAMPMODE
+    description: Enable sampled mode of comparator.
+    bit_offset: 24
+    bit_size: 1
+fieldset/CTL3:
+  description: Control 3.
+  fields:
+  - name: DACCODE
+    description: The two 8-bit DAC codes; DACCTL and DACSW select which one drives the DAC. When the code is 0x0 the DAC output is the selected reference voltage x 1/256 V, and when it is 0xFF, x 255/256 V.
+    bit_offset: 0
+    bit_size: 8
+    array:
+      len: 2
+      stride: 16
+fieldset/DESC:
+  description: Module Description.
+  fields:
+  - name: MINREV
+    description: Minor rev of the IP.
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major rev of the IP.
+    bit_offset: 4
+    bit_size: 4
+  - name: FEATUREVER
+    description: Feature Set for the module *instance*.
+    bit_offset: 12
+    bit_size: 4
+  - name: MODULEID
+    description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
+    bit_offset: 16
+    bit_size: 16
+fieldset/EVT_MODE:
+  description: Event Mode.
+  fields:
+  - name: CPU
+    description: Event line mode select for event corresponding to CPU_INT.
+    bit_offset: 0
+    bit_size: 2
+    enum: INT_CFG
+  - name: GEN_EVENT
+    description: Event line mode select for event corresponding to GEN_EVENT.
+    bit_offset: 2
+    bit_size: 2
+    enum: INT_CFG
+fieldset/FPORT:
+  description: Event subscriber/publisher channel selection.
+  fields:
+  - name: CHANID
+    description: 0 = disconnected. 1-15 = connected to channelID = CHANID.
+    bit_offset: 0
+    bit_size: 4
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    # Three bits, not the two every TI source states: the SVDs, hw_comp.h and the TRMs all mask
+    # STAT 0x3 while their own value lists reach 4h (OUTRDYIFG). Sibling IPs size it properly
+    # (WWDT 0x1F, ADC 0x3FF), so the 0x3 is a defect in the COMP IP description alone.
+    description: Interrupt index status.
+    bit_offset: 0
+    bit_size: 3
+    enum: IIDX_STAT
+fieldset/INT:
+  description: Interrupt.
+  fields:
+  - name: COMPIFG
+    description: Masks COMPIFG.
+    bit_offset: 1
+    bit_size: 1
+  - name: COMPINVIFG
+    description: Masks COMPINVIFG.
+    bit_offset: 2
+    bit_size: 1
+  - name: OUTRDYIFG
+    description: Masks OUTRDYIFG.
+    bit_offset: 3
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+fieldset/STAT:
+  description: Status.
+  fields:
+  - name: OUT
+    description: This bit reflects the value of the comparator output. Writing to this bit has no effect on the comparator output.
+    bit_offset: 0
+    bit_size: 1
+enum/BLANKSRC:
+  bit_size: 3
+  variants:
+  - name: DISABLE
+    description: Blanking source disabled.
+    value: 0
+  - name: BLANKSRC1
+    description: Select Blanking Source 1.
+    value: 1
+  - name: BLANKSRC2
+    description: Select Blanking Source 2.
+    value: 2
+  - name: BLANKSRC3
+    description: Select Blanking Source 3.
+    value: 3
+  - name: BLANKSRC4
+    description: Select Blanking Source 4.
+    value: 4
+  - name: BLANKSRC5
+    description: Select Blanking Source 5.
+    value: 5
+  - name: BLANKSRC6
+    description: Select Blanking Source 6.
+    value: 6
+enum/CLKCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 169
+enum/DACCTL:
+  bit_size: 1
+  variants:
+  - name: COMPOUT_SEL
+    description: Comparator output controls selection between DACCODE0 and DACCODE1.
+    value: 0
+  - name: DACSW_SEL
+    description: DACSW bit controls selection between DACCODE0 and DACCODE1.
+    value: 1
+enum/DACSW:
+  bit_size: 1
+  variants:
+  - name: DACCODE0_SEL
+    description: DACCODE0 selected for 8-bit DAC.
+    value: 0
+  - name: DACCODE1_SEL
+    description: DACCODE1 selected for 8-bit DAC.
+    value: 1
+enum/FLTDLY:
+  bit_size: 2
+  variants:
+  - name: DLY_0
+    description: Typical filter delay of 70 ns.
+    value: 0
+  - name: DLY_1
+    description: Typical filter delay of 500 ns.
+    value: 1
+  - name: DLY_2
+    description: Typical filter delay of 1200 ns.
+    value: 2
+  - name: DLY_3
+    description: Typical filter delay of 2700 ns.
+    value: 3
+enum/HYST:
+  bit_size: 2
+  variants:
+  - name: NO_HYS
+    description: No hysteresis.
+    value: 0
+  - name: LOW_HYS
+    description: Low hysteresis, typical 10mV.
+    value: 1
+  - name: MED_HYS
+    description: Medium hysteresis, typical 20mV.
+    value: 2
+  - name: HIGH_HYS
+    description: High hysteresis, typical 30mV.
+    value: 3
+enum/IES:
+  bit_size: 1
+  variants:
+  - name: RISING
+    description: Rising edge sets COMPIFG and falling edge sets COMPINVIFG.
+    value: 0
+  - name: FALLING
+    description: Falling edge sets COMPIFG and rising edge sets COMPINVIFG.
+    value: 1
+enum/IIDX_STAT:
+  bit_size: 3
+  variants:
+  - name: NO_INTR
+    description: No pending interrupt.
+    value: 0
+  - name: COMPIFG
+    description: Comparator output interrupt.
+    value: 2
+  - name: COMPINVIFG
+    description: Comparator output inverted interrupt.
+    value: 3
+  - name: OUTRDYIFG
+    description: Comparator output ready interrupt.
+    value: 4
+enum/INT_CFG:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: The interrupt or event line is disabled.
+    value: 0
+  - name: SOFTWARE
+    description: The interrupt or event line is in software mode. Software must clear the RIS.
+    value: 1
+  - name: HARDWARE
+    description: The interrupt or event line is in hardware mode. The hardware (another module) clears automatically the associated RIS flag.
+    value: 2
+enum/MODE:
+  bit_size: 1
+  variants:
+  - name: FAST
+    description: Comparator is in fast mode.
+    value: 0
+  - name: ULP
+    description: Comparator is in ultra-low power mode.
+    value: 1
+enum/OUTPOL:
+  bit_size: 1
+  variants:
+  - name: NON_INV
+    description: Comparator output is non-inverted.
+    value: 0
+  - name: INV
+    description: Comparator output is inverted.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/REFMODE:
+  bit_size: 1
+  variants:
+  - name: STATIC
+    description: ULP_REF bandgap, local reference buffer and 8-bit DAC inside comparator operate in static mode.
+    value: 0
+  - name: SAMPLED
+    description: ULP_REF bandgap, local reference buffer and 8-bit DAC inside comparator operate in sampled mode.
+    value: 1
+enum/REFSEL:
+  bit_size: 1
+  variants:
+  - name: POSITIVE
+    description: If EXCH bit is 0, the selected reference is applied to positive terminal. If EXCH bit is 1, the selected reference is applied to negative terminal.
+    value: 0
+  - name: NEGATIVE
+    description: If EXCH bit is 0, the selected reference is applied to negative terminal. If EXCH bit is 1, the selected reference is applied to positive terminal.
+    value: 1
+enum/REFSRC:
+  bit_size: 3
+  variants:
+  - name: OFF
+    description: Reference voltage generator is disabled (local reference buffer as well as DAC).
+    value: 0
+  - name: VDDA_DAC
+    description: VDDA selected as the reference source to DAC and DAC output applied as reference to comparator.
+    value: 1
+  - name: VREF_DAC
+    description: VREF selected as reference to DAC and DAC output applied as reference to comparator.
+    value: 2
+  - name: VREF
+    description: In devices where internal VREF is buffered and hookedup to extrernal VREF pin, VREF applied as reference to comparator. DAC is switched off.
+    value: 3
+  - name: VDDA
+    description: VDDA is used as comparator reference.
+    value: 5
+  - name: INTVREF_DAC
+    description: Internal reference selected as the reference source to DAC and DAC output applied as reference to comparator.
+    value: 6
+  - name: INTVREF
+    description: Internal VREF is used as the source of comparator. Not all devices will have this option.
+    value: 7
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/cpuss_v1.yaml
+++ b/data/registers/cpuss_v1.yaml
@@ -12,25 +12,65 @@ block/CPUSS:
     access: Read
     fieldset: DESC
   - name: INT_GROUP
+    description: CPUSS Interrupt group (x = 0..2). Depending on the model, the later elements of this array may be undefined. For C110x only index 0 is valid. Meanwhile for L222x indices 0 and 1 are valid.
     array:
       len: 2
       stride: 48
-    description: CPUSS Interrupt group (x = 0..2). Depending on the model, the later elements of this array may be undefined. For C110x only index 0 is valid. Meanwhile for L222x indices 0 and 1 are valid. 
     byte_offset: 4352
     block: INT_GROUP
   - name: CTL
     description: Prefetch/Cache control.
     byte_offset: 4864
     fieldset: CTL
-
-fieldset/EVT_MODE:
-  description: Event Mode.
+# The interrupt group is shared across all CPUSS variants.
+block/INT_GROUP:
+  description: Interrupt group.
+  items:
+  - name: IIDX
+    description: Interrupt index
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    access: Read
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+fieldset/CTL:
+  description: Prefetch/Cache control.
   fields:
-  - name: INT_CFG
-    description: Event line mode select.
+  - name: PREFETCH
+    description: Used to enable/disable instruction prefetch to Flash.
     bit_offset: 0
-    bit_size: 2
-    enum: INT_CFG
+    bit_size: 1
+  - name: ICACHE
+    description: Used to enable/disable Instruction caching on flash access.
+    bit_offset: 1
+    bit_size: 1
+  - name: LITEN
+    description: Literal caching and prefetch enable. This bit is a subset of ICACHE/PREFETCH bit i.e. literal caching or literal prefetching will only happen if ICACHE or PREFETCH bits have been set respectively When enabled, the cache and prefetcher structures inside CPUSS will cache and prefetch literals When disabled, the cache and prefetcher structures inside CPUSS will not cache and prefetch literals.
+    bit_offset: 2
+    bit_size: 1
 fieldset/DESC:
   description: Module Description.
   fields:
@@ -50,54 +90,14 @@ fieldset/DESC:
     description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
     bit_offset: 16
     bit_size: 16
-enum/INT_CFG:
-  bit_size: 2
-  variants:
-  - name: DISABLE
-    description: The interrupt or event line is disabled.
-    value: 0
-  - name: SOFTWARE
-    description: Event handled by software. Software must clear the associated RIS flag.
-    value: 1
-  - name: HARDWARE
-    description: Event handled by hardware. The hardware (another module) clears automatically the associated RIS flag.
-    value: 2
-
-# The interrupt group is shared across all CPUSS variants.
-block/INT_GROUP:
-  description: Interrupt group.
-  items:
-  - name: IIDX
-    description: Interrupt index
-    byte_offset: 0
-    access: Read
-    fieldset: IIDX
-  - name: IMASK
-    description: Interrupt mask.
-    byte_offset: 8
-    access: Read
-    fieldset: IMASK
-  - name: RIS
-    description: Raw interrupt status.
-    byte_offset: 16
-    access: Read
-    fieldset: RIS
-  - name: MIS
-    description: Masked interrupt status.
-    byte_offset: 24
-    access: Read
-    fieldset: MIS
-  - name: ISET
-    description: Interrupt set.
-    byte_offset: 32
-    access: Write
-    fieldset: ISET
-  - name: ICLR
-    description: Interrupt clear.
-    byte_offset: 40
-    access: Write
-    fieldset: ICLR
-
+fieldset/EVT_MODE:
+  description: Event Mode.
+  fields:
+  - name: INT_CFG
+    description: Event line mode select.
+    bit_offset: 0
+    bit_size: 2
+    enum: INT_CFG
 fieldset/IIDX:
   description: Interrupt index.
   fields:
@@ -106,47 +106,13 @@ fieldset/IIDX:
     bit_offset: 0
     bit_size: 8
     enum: IIDX
-fieldset/IMASK:
-  description: Interrupt mask.
+fieldset/INT:
+  description: One bit per interrupt in the group. Shared by IMASK, RIS, MIS, ISET and ICLR.
   fields:
   - name: INT
-    description: Masks the corresponding interrupt.
+    description: The interrupts of the group, as a mask.
     bit_offset: 0
     bit_size: 8
-    enum: IMASK
-fieldset/RIS:
-  description: Raw interrupt status.
-  fields:
-  - name: INT
-    description: Raw interrupt status for INT.
-    bit_offset: 0
-    bit_size: 8
-    enum: RIS
-fieldset/MIS:
-  description: Masked interrupt status.
-  fields:
-  - name: INT
-    description: Masked interrupt status for INT.
-    bit_offset: 0
-    bit_size: 8
-    enum: MIS
-fieldset/ISET:
-  description: Interrupt set.
-  fields:
-  - name: INT
-    description: Sets INT in RIS register.
-    bit_offset: 0
-    bit_size: 8
-    enum: ISET
-fieldset/ICLR:
-  description: Interrupt clear.
-  fields:
-  - name: INT
-    description: Clears INT in RIS register.
-    bit_offset: 0
-    bit_size: 8
-    enum: ICLR
-
 enum/IIDX:
   bit_size: 8
   variants:
@@ -177,95 +143,15 @@ enum/IIDX:
   - name: INT7
     description: Interrupt 7.
     value: 8
-enum/IMASK:
-  bit_size: 8
-  variants:
-  - name: CLR
-    description: Interrupt is masked out.
-    value: 0
-  - name: SET
-    description: Interrupt will request an interrupt service routine and corresponding bit in MIS will be set.
-    value: 1
-enum/RIS:
-  bit_size: 8
-  variants:
-  - name: CLR
-    description: INT did not occur.
-    value: 0
-  - name: SET
-    description: INT occurred.
-    value: 1
-enum/MIS:
-  bit_size: 8
-  variants:
-  - name: CLR
-    description: INT does not request an interrupt service routine.
-    value: 0
-  - name: SET
-    description: INT requests an interrupt service routine.
-    value: 1
-enum/ISET:
-  bit_size: 8
-  variants:
-  - name: NO_EFFECT
-    description: Writing a 0 has no effect.
-    value: 0
-  - name: SET
-    description: RIS bit corresponding to INT is set.
-    value: 1
-enum/ICLR:
-  bit_size: 8
-  variants:
-  - name: NO_EFFECT
-    description: Writing a 0 has no effect.
-    value: 0
-  - name: CLR
-    description: RIS bit corresponding to INT is cleared.
-    value: 1
-
-fieldset/CTL:
-  description: Prefetch/Cache control.
-  fields:
-  - name: PREFETCH
-    description: Used to enable/disable instruction prefetch to Flash.
-    bit_offset: 0
-    bit_size: 1
-    enum: PREFETCH
-  - name: ICACHE
-    description: Used to enable/disable Instruction caching on flash access.
-    bit_offset: 1
-    bit_size: 1
-    enum: ICACHE
-  - name: LITEN
-    description: Literal caching and prefetch enable. This bit is a subset of ICACHE/PREFETCH bit i.e. literal caching or literal prefetching will only happen if ICACHE or PREFETCH bits have been set respectively When enabled, the cache and prefetcher structures inside CPUSS will cache and prefetch literals When disabled, the cache and prefetcher structures inside CPUSS will not cache and prefetch literals.
-    bit_offset: 2
-    bit_size: 1
-    enum: LITEN
-
-enum/ICACHE:
-  bit_size: 1
+enum/INT_CFG:
+  bit_size: 2
   variants:
   - name: DISABLE
-    description: Disable instruction caching.
+    description: The interrupt or event line is disabled.
     value: 0
-  - name: ENABLE
-    description: Enable instruction caching.
+  - name: SOFTWARE
+    description: Event handled by software. Software must clear the associated RIS flag.
     value: 1
-enum/LITEN:
-  bit_size: 1
-  variants:
-  - name: DISABLE
-    description: Literal caching disabled.
-    value: 0
-  - name: ENABLE
-    description: Literal caching enabled.
-    value: 1
-enum/PREFETCH:
-  bit_size: 1
-  variants:
-  - name: DISABLE
-    description: Disable instruction prefetch.
-    value: 0
-  - name: ENABLE
-    description: Enable instruction prefetch.
-    value: 1
+  - name: HARDWARE
+    description: Event handled by hardware. The hardware (another module) clears automatically the associated RIS flag.
+    value: 2

--- a/data/registers/cpuss_v1.yaml
+++ b/data/registers/cpuss_v1.yaml
@@ -22,9 +22,8 @@ block/CPUSS:
     description: Prefetch/Cache control.
     byte_offset: 4864
     fieldset: CTL
-# The interrupt group is shared across all CPUSS variants.
 block/INT_GROUP:
-  description: Interrupt group.
+  description: Interrupt group. Shared across all CPUSS variants.
   items:
   - name: IIDX
     description: Interrupt index

--- a/data/registers/cpuss_v1.yaml
+++ b/data/registers/cpuss_v1.yaml
@@ -128,7 +128,7 @@ fieldset/MIS:
   - name: INT
     description: Masked interrupt status for INT.
     bit_offset: 0
-    bit_size: 1
+    bit_size: 8
     enum: MIS
 fieldset/ISET:
   description: Interrupt set.
@@ -136,7 +136,7 @@ fieldset/ISET:
   - name: INT
     description: Sets INT in RIS register.
     bit_offset: 0
-    bit_size: 1
+    bit_size: 8
     enum: ISET
 fieldset/ICLR:
   description: Interrupt clear.
@@ -144,7 +144,7 @@ fieldset/ICLR:
   - name: INT
     description: Clears INT in RIS register.
     bit_offset: 0
-    bit_size: 1
+    bit_size: 8
     enum: ICLR
 
 enum/IIDX:
@@ -196,7 +196,7 @@ enum/RIS:
     description: INT occurred.
     value: 1
 enum/MIS:
-  bit_size: 1
+  bit_size: 8
   variants:
   - name: CLR
     description: INT does not request an interrupt service routine.
@@ -205,7 +205,7 @@ enum/MIS:
     description: INT requests an interrupt service routine.
     value: 1
 enum/ISET:
-  bit_size: 1
+  bit_size: 8
   variants:
   - name: NO_EFFECT
     description: Writing a 0 has no effect.
@@ -214,7 +214,7 @@ enum/ISET:
     description: RIS bit corresponding to INT is set.
     value: 1
 enum/ICLR:
-  bit_size: 1
+  bit_size: 8
   variants:
   - name: NO_EFFECT
     description: Writing a 0 has no effect.

--- a/data/registers/crc_16.yaml
+++ b/data/registers/crc_16.yaml
@@ -1,0 +1,150 @@
+block/CRC:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: DESC
+    description: Module Description.
+    byte_offset: 4348
+    access: Read
+    fieldset: DESC
+  - name: CTRL
+    description: CRC control.
+    byte_offset: 4352
+    fieldset: CTRL
+  - name: SEED
+    description: CRC seed.
+    byte_offset: 4356
+    access: Write
+  - name: IN
+    description: CRC input data.
+    byte_offset: 4360
+    access: Write
+  - name: OUT
+    description: CRC result.
+    byte_offset: 4364
+    access: Read
+  - name: IN_IDX
+    description: CRC input data, memory-mapped region. A write anywhere in it feeds the engine; the index only serves address-incrementing DMA.
+    array:
+      len: 512
+      stride: 4
+    byte_offset: 6144
+    access: Write
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: GPRCM_STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+fieldset/CTRL:
+  description: CRC control.
+  # No POLYSIZE: these devices implement CRC-16 only. Their headers state it per device
+  # (CRC_SYS_CRC32_ENABLE = 0) and their SVDs omit the field; SLAU893 SS17.1 describes the C-series
+  # generator as CRC16-CCITT alone. The TRM's own register table still shows POLYSIZE - it is the
+  # portfolio-shared chapter, not the device.
+  fields:
+  - name: BITREVERSE
+    description: CRC Bit Input and output Reverse. This bit indictes that the bit order of each input byte used for the CRC calculation is reversed before it is passed to the generator, and that the bit order of the calculated CRC is be reversed when read from CRC_RESULT.
+    bit_offset: 1
+    bit_size: 1
+  - name: INPUT_ENDIANNESS
+    description: CRC Endian. This bit indicates the byte order within a word or half word of input data.
+    bit_offset: 2
+    bit_size: 1
+    enum: INPUT_ENDIANNESS
+  - name: OUTPUT_BYTESWAP
+    description: 'CRC Output Byteswap Enable. This bit controls whether the output is byte-swapped upon a read of the CRCOUT register. If CRCOUT is accessed as a half-word, and the OUTPUT_BYTESWAP is set to to 1, then the two bytes in the 16-bit access are swapped and returned. B1 is returned as B0 B0 is returned as B1 If CRCOUT is accessed as a word, and the OUTPUT_BYTESWAP is set to 1, then the four bytes in the 32-bit read are swapped. B3 is returned as B0 B2 is returned as B1 B1 is returned as B2 B0 is returned as B3 Note that if the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP enabled, then the output is: MSB LSB 0x0 0x0 B0 B1 If the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP disabled, then the output is: MSB LSB 0x0 0x0 B1 B0.'
+    bit_offset: 4
+    bit_size: 1
+fieldset/DESC:
+  description: Module Description.
+  fields:
+  - name: MINREV
+    description: Minor rev of the IP.
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major rev of the IP.
+    bit_offset: 4
+    bit_size: 4
+  - name: INSTNUM
+    description: Instance Number within the device. This will be a parameter to the RTL for modules that can have multiple instances.
+    bit_offset: 8
+    bit_size: 4
+  - name: FEATUREVER
+    description: Feature Set for the module *instance*.
+    bit_offset: 12
+    bit_size: 4
+  - name: MODULEID
+    description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
+    bit_offset: 16
+    bit_size: 16
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+enum/INPUT_ENDIANNESS:
+  bit_size: 1
+  variants:
+  - name: LITTLE_ENDIAN
+    description: LSB is lowest memory address and first to be processed.
+    value: 0
+  - name: BIG_ENDIAN
+    description: LSB is highest memory address and last to be processed.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/crc_p.yaml
+++ b/data/registers/crc_p.yaml
@@ -1,0 +1,163 @@
+block/CRC:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: DESC
+    description: Module Description.
+    byte_offset: 4348
+    access: Read
+    fieldset: DESC
+  - name: CTRL
+    description: CRC control.
+    byte_offset: 4352
+    fieldset: CTRL
+  - name: SEED
+    description: CRC seed.
+    byte_offset: 4356
+    access: Write
+  - name: IN
+    description: CRC input data.
+    byte_offset: 4360
+    access: Write
+  - name: OUT
+    description: CRC result.
+    byte_offset: 4364
+    access: Read
+  - name: POLY
+    description: CRC polynomial. Bit positions above the configured POLYSIZE are ignored.
+    byte_offset: 4368
+  - name: IN_IDX
+    description: CRC input data, memory-mapped region. A write anywhere in it feeds the engine; the index only serves address-incrementing DMA.
+    array:
+      len: 512
+      stride: 4
+    byte_offset: 6144
+    access: Write
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: GPRCM_STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+fieldset/CTRL:
+  description: CRC control.
+  fields:
+  - name: POLYSIZE
+    description: This bit indicates which CRC calculation is performed by the generator.
+    bit_offset: 0
+    bit_size: 1
+    enum: POLYSIZE
+  - name: BITREVERSE
+    description: CRC Bit Input and output Reverse. This bit indictes that the bit order of each input byte used for the CRC calculation is reversed before it is passed to the generator, and that the bit order of the calculated CRC is be reversed when read from CRC_RESULT.
+    bit_offset: 1
+    bit_size: 1
+  - name: INPUT_ENDIANNESS
+    description: CRC Endian. This bit indicates the byte order within a word or half word of input data.
+    bit_offset: 2
+    bit_size: 1
+    enum: INPUT_ENDIANNESS
+  - name: OUTPUT_BYTESWAP
+    description: 'CRC Output Byteswap Enable. This bit controls whether the output is byte-swapped upon a read of the CRCOUT register. If CRCOUT is accessed as a half-word, and the OUTPUT_BYTESWAP is set to to 1, then the two bytes in the 16-bit access are swapped and returned. B1 is returned as B0 B0 is returned as B1 If CRCOUT is accessed as a word, and the OUTPUT_BYTESWAP is set to 1, then the four bytes in the 32-bit read are swapped. B3 is returned as B0 B2 is returned as B1 B1 is returned as B2 B0 is returned as B3 Note that if the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP enabled, then the output is: MSB LSB 0x0 0x0 B0 B1 If the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP disabled, then the output is: MSB LSB 0x0 0x0 B1 B0.'
+    bit_offset: 4
+    bit_size: 1
+fieldset/DESC:
+  description: Module Description.
+  fields:
+  - name: MINREV
+    description: Minor rev of the IP.
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major rev of the IP.
+    bit_offset: 4
+    bit_size: 4
+  - name: INSTNUM
+    description: Instance Number within the device. This will be a parameter to the RTL for modules that can have multiple instances.
+    bit_offset: 8
+    bit_size: 4
+  - name: FEATUREVER
+    description: Feature Set for the module *instance*.
+    bit_offset: 12
+    bit_size: 4
+  - name: MODULEID
+    description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
+    bit_offset: 16
+    bit_size: 16
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+enum/INPUT_ENDIANNESS:
+  bit_size: 1
+  variants:
+  - name: LITTLE_ENDIAN
+    description: LSB is lowest memory address and first to be processed.
+    value: 0
+  - name: BIG_ENDIAN
+    description: LSB is highest memory address and last to be processed.
+    value: 1
+enum/POLYSIZE:
+  bit_size: 1
+  variants:
+  - name: CRC32
+    description: CRC-32 ISO-3309 calulation is performed.
+    value: 0
+  - name: CRC16
+    description: CRC-16 CCITT is performed.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/crc_v1.yaml
+++ b/data/registers/crc_v1.yaml
@@ -1,0 +1,160 @@
+block/CRC:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: DESC
+    description: Module Description.
+    byte_offset: 4348
+    access: Read
+    fieldset: DESC
+  - name: CTRL
+    description: CRC control.
+    byte_offset: 4352
+    fieldset: CTRL
+  - name: SEED
+    description: CRC seed.
+    byte_offset: 4356
+    access: Write
+  - name: IN
+    description: CRC input data.
+    byte_offset: 4360
+    access: Write
+  - name: OUT
+    description: CRC result.
+    byte_offset: 4364
+    access: Read
+  - name: IN_IDX
+    description: CRC input data, memory-mapped region. A write anywhere in it feeds the engine; the index only serves address-incrementing DMA.
+    array:
+      len: 512
+      stride: 4
+    byte_offset: 6144
+    access: Write
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: GPRCM_STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: GPRCM_STAT
+fieldset/CTRL:
+  description: CRC control.
+  fields:
+  - name: POLYSIZE
+    description: This bit indicates which CRC calculation is performed by the generator.
+    bit_offset: 0
+    bit_size: 1
+    enum: POLYSIZE
+  - name: BITREVERSE
+    description: CRC Bit Input and output Reverse. This bit indictes that the bit order of each input byte used for the CRC calculation is reversed before it is passed to the generator, and that the bit order of the calculated CRC is be reversed when read from CRC_RESULT.
+    bit_offset: 1
+    bit_size: 1
+  - name: INPUT_ENDIANNESS
+    description: CRC Endian. This bit indicates the byte order within a word or half word of input data.
+    bit_offset: 2
+    bit_size: 1
+    enum: INPUT_ENDIANNESS
+  - name: OUTPUT_BYTESWAP
+    description: 'CRC Output Byteswap Enable. This bit controls whether the output is byte-swapped upon a read of the CRCOUT register. If CRCOUT is accessed as a half-word, and the OUTPUT_BYTESWAP is set to to 1, then the two bytes in the 16-bit access are swapped and returned. B1 is returned as B0 B0 is returned as B1 If CRCOUT is accessed as a word, and the OUTPUT_BYTESWAP is set to 1, then the four bytes in the 32-bit read are swapped. B3 is returned as B0 B2 is returned as B1 B1 is returned as B2 B0 is returned as B3 Note that if the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP enabled, then the output is: MSB LSB 0x0 0x0 B0 B1 If the CRC POLYSIZE is 16-bit and a 32-bit read of CRCOUT is performed with OUTPUT_BYTESWAP disabled, then the output is: MSB LSB 0x0 0x0 B1 B0.'
+    bit_offset: 4
+    bit_size: 1
+fieldset/DESC:
+  description: Module Description.
+  fields:
+  - name: MINREV
+    description: Minor rev of the IP.
+    bit_offset: 0
+    bit_size: 4
+  - name: MAJREV
+    description: Major rev of the IP.
+    bit_offset: 4
+    bit_size: 4
+  - name: INSTNUM
+    description: Instance Number within the device. This will be a parameter to the RTL for modules that can have multiple instances.
+    bit_offset: 8
+    bit_size: 4
+  - name: FEATUREVER
+    description: Feature Set for the module *instance*.
+    bit_offset: 12
+    bit_size: 4
+  - name: MODULEID
+    description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
+    bit_offset: 16
+    bit_size: 16
+fieldset/GPRCM_STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+enum/INPUT_ENDIANNESS:
+  bit_size: 1
+  variants:
+  - name: LITTLE_ENDIAN
+    description: LSB is lowest memory address and first to be processed.
+    value: 0
+  - name: BIG_ENDIAN
+    description: LSB is highest memory address and last to be processed.
+    value: 1
+enum/POLYSIZE:
+  bit_size: 1
+  variants:
+  - name: CRC32
+    description: CRC-32 ISO-3309 calulation is performed.
+    value: 0
+  - name: CRC16
+    description: CRC-16 CCITT is performed.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/flashctl_v1.yaml
+++ b/data/registers/flashctl_v1.yaml
@@ -251,6 +251,14 @@ fieldset/CMDCTL:
     bit_offset: 9
     bit_size: 4
     enum: REGIONSEL
+  # PREVEREN, POSTVEREN, PROGMASKDIS and ERASEMASKDIS are documented only by the SLAU847/893/923
+  # CMDCTL field tables; SLAU846 marks bits 20-18 and 15-14 reserved, and hw_flashctl.h and the
+  # SVDs omit all four (they do carry SSERASEDIS and DATAVEREN, so SLAU846's reserved span is
+  # wrong about bit 20 either way). Kept: the MASKDIS descriptions name the prever/postver
+  # machinery these bits control. The field tables give PREVEREN/POSTVEREN a 1h reset where the
+  # same sections' figures and [Reset =] headers say 0 — clearing them disables the
+  # verify-and-repulse loop, leaving marginal cells with no error, so never write CMDCTL whole:
+  # driverlib only ever read-modify-writes it (BANKSEL, REGIONSEL, ECCGENOVR).
   - name: PREVEREN
     description: Enable verify before program or erase. For program, bits already programmed to the requests value will be masked. For erase, sectors already erased will be masked.
     bit_offset: 14

--- a/data/registers/flashctl_v1.yaml
+++ b/data/registers/flashctl_v1.yaml
@@ -166,7 +166,6 @@ fieldset/BANKINFO0:
     description: 'Main region size in sectors Minimum: 0x8 (8) Maximum: 0x200 (512).'
     bit_offset: 0
     bit_size: 12
-    enum: BANKINFO_MAINSIZE
 fieldset/BANKINFO1:
   description: Bank Information Register 1.
   fields:
@@ -174,17 +173,14 @@ fieldset/BANKINFO1:
     description: 'Non-main region size in sectors Minimum: 0x0 (0) Maximum: 0x10 (16).'
     bit_offset: 0
     bit_size: 8
-    enum: BANKINFO_NONMAINSIZE
   - name: TRIMSIZE
     description: 'Trim region size in sectors Minimum: 0x0 (0) Maximum: 0x10 (16).'
     bit_offset: 8
     bit_size: 8
-    enum: BANKINFO_TRIMSIZE
   - name: ENGRSIZE
     description: 'Engr region size in sectors Minimum: 0x0 (0) Maximum: 0x10 (16).'
     bit_offset: 16
     bit_size: 8
-    enum: BANKINFO_ENGRSIZE
 fieldset/CFGCMD:
   description: Command Configuration Register.
   fields:
@@ -290,14 +286,13 @@ fieldset/CMDCTL:
 fieldset/CMDDATAECC:
   description: Command Data Register ECC 0.
   fields:
-  - name: VAL0
-    description: ECC data for bits 63:0 of the data is placed here.
+  - name: VAL
+    description: 'ECC data for one 64 bit half of the data: index 0 covers bits 63:0 and index 1 bits 127:64.'
     bit_offset: 0
     bit_size: 8
-  - name: VAL1
-    description: ECC data for bits 127:64 of the data is placed here.
-    bit_offset: 8
-    bit_size: 8
+    array:
+      len: 2
+      stride: 8
 fieldset/CMDDATAINDEX:
   description: Command Data Index Register.
   fields:
@@ -378,7 +373,6 @@ fieldset/GBLINFO0:
     description: 'Number of banks instantiated Minimum: 1 Maximum: 5.'
     bit_offset: 16
     bit_size: 3
-    enum: NUMBANKS
 fieldset/GBLINFO1:
   description: Global Information Register 1.
   fields:
@@ -435,7 +429,7 @@ fieldset/STATADDR:
     description: Current Bank ID A bank indicator is stored in this register which represents the current bank on which the state machine is operating. There is 1 bit per bank.
     bit_offset: 21
     bit_size: 5
-    enum: BANKID
+    enum: BANK
 fieldset/STATCMD:
   description: Command Status Register.
   fields:
@@ -521,60 +515,6 @@ enum/BANK:
   - name: BANK4
     description: Bank 4.
     value: 16
-enum/BANKID:
-  bit_size: 5
-  variants:
-  - name: BANK0
-    description: Bank 0.
-    value: 1
-  - name: BANK1
-    description: Bank 1.
-    value: 2
-  - name: BANK2
-    description: Bank 2.
-    value: 4
-  - name: BANK3
-    description: Bank 3.
-    value: 8
-  - name: BANK4
-    description: Bank 4.
-    value: 16
-enum/BANKINFO_ENGRSIZE:
-  bit_size: 8
-  variants:
-  - name: MINSECTORS
-    description: Minimum value of [ENGRSIZE].
-    value: 0
-  - name: MAXSECTORS
-    description: Maximum value of [ENGRSIZE].
-    value: 32
-enum/BANKINFO_MAINSIZE:
-  bit_size: 12
-  variants:
-  - name: MINSECTORS
-    description: Minimum value of [MAINSIZE].
-    value: 8
-  - name: MAXSECTORS
-    description: Maximum value of [MAINSIZE].
-    value: 512
-enum/BANKINFO_NONMAINSIZE:
-  bit_size: 8
-  variants:
-  - name: MINSECTORS
-    description: Minimum value of [NONMAINSIZE].
-    value: 0
-  - name: MAXSECTORS
-    description: Maximum value of [NONMAINSIZE].
-    value: 32
-enum/BANKINFO_TRIMSIZE:
-  bit_size: 8
-  variants:
-  - name: MINSECTORS
-    description: Minimum value of [TRIMSIZE].
-    value: 0
-  - name: MAXSECTORS
-    description: Maximum value of [TRIMSIZE].
-    value: 32
 enum/COMMAND:
   bit_size: 3
   variants:
@@ -668,13 +608,6 @@ enum/MODE:
   - name: ERASEBNK
     description: Erase Bank.
     value: 15
-enum/NUMBANKS:
-  bit_size: 3
-  variants:
-  - name: MINBANKS
-    value: 1
-  - name: MAXBANKS
-    value: 5
 enum/REDWIDTH:
   bit_size: 3
   variants:

--- a/data/registers/gpio_v1.yaml
+++ b/data/registers/gpio_v1.yaml
@@ -8,27 +8,27 @@ block/CPU_INT:
   - name: IMASK
     description: Interrupt mask.
     byte_offset: 8
-    fieldset: CPU_INT
+    fieldset: DIO
   - name: RIS
     description: Raw interrupt status.
     byte_offset: 16
     access: Read
-    fieldset: CPU_INT
+    fieldset: DIO
   - name: MIS
     description: Masked interrupt status.
     byte_offset: 24
     access: Read
-    fieldset: CPU_INT
+    fieldset: DIO
   - name: ISET
     description: Interrupt set.
     byte_offset: 32
     access: Write
-    fieldset: CPU_INT
+    fieldset: DIO
   - name: ICLR
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: CPU_INT
+    fieldset: DIO
 block/GEN_EVENT:
   items:
   - name: IIDX
@@ -39,27 +39,27 @@ block/GEN_EVENT:
   - name: IMASK
     description: Interrupt mask.
     byte_offset: 8
-    fieldset: GEN_EVENT
+    fieldset: DIO
   - name: RIS
     description: Raw interrupt status.
     byte_offset: 16
     access: Read
-    fieldset: GEN_EVENT
+    fieldset: DIO
   - name: MIS
     description: Masked interrupt status.
     byte_offset: 24
     access: Read
-    fieldset: GEN_EVENT
+    fieldset: DIO
   - name: ISET
     description: Interrupt set.
     byte_offset: 32
     access: Write
-    fieldset: GEN_EVENT
+    fieldset: DIO
   - name: ICLR
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: GEN_EVENT
+    fieldset: DIO
 block/GPIO:
   description: PERIPHERALREGION.
   items:
@@ -113,40 +113,40 @@ block/GPIO:
       stride: 4
     byte_offset: 4608
     access: Write
-    fieldset: DOUT_X4
+    fieldset: DIO_X4
   - name: DOUT31_0
     description: Data output 31 to 0.
     byte_offset: 4736
-    fieldset: DOUT31_0
+    fieldset: DIO
   - name: DOUTSET31_0
     description: Data output set 31 to 0.
     byte_offset: 4752
     access: Write
-    fieldset: DOUTSET31_0
+    fieldset: DIO
   - name: DOUTCLR31_0
     description: Data output clear 31 to 0.
     byte_offset: 4768
     access: Write
-    fieldset: DOUTCLR31_0
+    fieldset: DIO
   - name: DOUTTGL31_0
     description: Data output toggle 31 to 0.
     byte_offset: 4784
     access: Write
-    fieldset: DOUTTGL31_0
+    fieldset: DIO
   - name: DOE31_0
     description: Data output enable 31 to 0.
     byte_offset: 4800
-    fieldset: DOE31_0
+    fieldset: DIO
   - name: DOESET31_0
     description: Data output enable set 31 to 0.
     byte_offset: 4816
     access: Write
-    fieldset: DOESET31_0
+    fieldset: DIO
   - name: DOECLR31_0
     description: Data output enable clear 31 to 0.
     byte_offset: 4832
     access: Write
-    fieldset: DOECLR31_0
+    fieldset: DIO
   - name: DIN_Y_X4
     description: Data input 3 to 0.
     array:
@@ -154,20 +154,20 @@ block/GPIO:
       stride: 4
     byte_offset: 4864
     access: Read
-    fieldset: DIN_X4
+    fieldset: DIO_X4
   - name: DIN31_0
     description: Data input 31 to 0.
     byte_offset: 4992
     access: Read
-    fieldset: DIN31_0
+    fieldset: DIO
   - name: POLARITY15_0
     description: Polarity 15 to 0.
     byte_offset: 5008
-    fieldset: POLARITY15_0
+    fieldset: POLARITY
   - name: POLARITY31_16
     description: Polarity 31 to 16.
     byte_offset: 5024
-    fieldset: POLARITY31_16
+    fieldset: POLARITY
   - name: CTL
     description: FAST WAKE GLOBAL EN.
     byte_offset: 5120
@@ -223,16 +223,6 @@ fieldset/CLKOVR:
     bit_offset: 1
     bit_size: 1
     enum: RUN_STOP
-fieldset/CPU_INT:
-  description: Interrupt clear.
-  fields:
-  - name: DIO
-    description: DIO0 event.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
 fieldset/CPU_INT_IIDX:
   description: Interrupt index.
   fields:
@@ -267,21 +257,24 @@ fieldset/DESC:
     description: Module identification contains a unique peripheral identification number. The assignments are maintained in a central database for all of the platform modules to ensure uniqueness.
     bit_offset: 16
     bit_size: 16
-fieldset/DIN31_0:
-  description: Data input 31 to 0.
+fieldset/DIO:
+  # Every one of these registers is a mask over the port's 32 DIO pins, indexed by DIO number.
+  # In the two generic event blocks only one half is implemented: GEN_EVENT0 has DIO0 to DIO15 and
+  # GEN_EVENT1 has DIO16 to DIO31, each at the bit matching its own DIO number.
+  description: A mask over the port's DIO pins.
   fields:
   - name: DIO
-    description: This bit reads the data input value of DIO0.
+    description: One bit per DIO pin.
     bit_offset: 0
     bit_size: 1
     array:
       len: 32
       stride: 1
-fieldset/DIN_X4:
-  description: Data input 11 to 8.
+fieldset/DIO_X4:
+  description: Four DIO pins, one per byte of the word.
   fields:
   - name: DIO
-    description: This bit reads the data input value of DIO8.
+    description: The value of one DIO pin.
     bit_offset: 0
     bit_size: 1
     array:
@@ -297,86 +290,6 @@ fieldset/DMAMASK:
     array:
       len: 32
       stride: 1
-fieldset/DOE31_0:
-  description: Data output enable 31 to 0.
-  fields:
-  - name: DIO
-    description: Enables data output for DIO0.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOECLR31_0:
-  description: Data output enable clear 31 to 0.
-  fields:
-  - name: DIO
-    description: Writing 1 to this bit clears the DIO0 bit in the DOE31_0 register. Writing 0 has no effect.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOESET31_0:
-  description: Data output enable set 31 to 0.
-  fields:
-  - name: DIO
-    description: Writing 1 to this bit sets the DIO0 bit in the DOE31_0 register. Writing 0 has no effect.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOUT31_0:
-  description: Data output 31 to 0.
-  fields:
-  - name: DIO
-    description: This bit sets the value of the pin configured as DIO0 when the output is enabled through DOE31_0 register.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOUTCLR31_0:
-  description: Data output clear 31 to 0.
-  fields:
-  - name: DIO
-    description: Writing 1 to this bit clears the DIO0 bit in the DOUT31_0 register. Writing 0 has no effect.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOUTSET31_0:
-  description: Data output set 31 to 0.
-  fields:
-  - name: DIO
-    description: Writing 1 to this bit sets the DIO0 bit in the DOUT31_0 register. Writing 0 has no effect.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOUTTGL31_0:
-  description: Data output toggle 31 to 0.
-  fields:
-  - name: DIO
-    description: This bit is used to toggle DIO0 output.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
-fieldset/DOUT_X4:
-  description: Data output 11 to 8.
-  fields:
-  - name: DIO
-    description: This bit sets the value of the pin configured as DIO8 when the output is enabled through DOE31_0 register.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 4
-      stride: 8
 fieldset/EVT_MODE:
   description: Event Mode.
   fields:
@@ -421,19 +334,6 @@ fieldset/FPORT:
     description: 0 = disconnected. 1-15 = connected to channelID = CHANID.
     bit_offset: 0
     bit_size: 4
-fieldset/GEN_EVENT:
-  # Indexed by absolute DIO number, so that it agrees with CPU_INT and the DOUT/DIN masks.
-  # GEN_EVENT0 implements DIO0 to DIO15 and GEN_EVENT1 implements DIO16 to DIO31, each at the bit
-  # matching its own DIO number; the other half of the word is reserved in both.
-  description: Generic event mask, one bit per DIO.
-  fields:
-  - name: DIO
-    description: DIO event.
-    bit_offset: 0
-    bit_size: 1
-    array:
-      len: 32
-      stride: 1
 fieldset/GEN_EVENT_IIDX:
   description: Interrupt index.
   fields:
@@ -449,22 +349,11 @@ fieldset/PDBGCTL:
     description: Free run control.
     bit_offset: 0
     bit_size: 1
-fieldset/POLARITY15_0:
-  description: Polarity 15 to 0.
+fieldset/POLARITY:
+  description: Edge detection polarity for sixteen DIO pins, two bits each.
   fields:
   - name: DIO
-    description: Enables and configures edge detection polarity for DIO0.
-    bit_offset: 0
-    bit_size: 2
-    array:
-      len: 16
-      stride: 2
-    enum: POLARITY
-fieldset/POLARITY31_16:
-  description: Polarity 31 to 16.
-  fields:
-  - name: DIO
-    description: Enables and configures edge detection polarity for DIO16.
+    description: Enables and configures edge detection polarity for one DIO.
     bit_offset: 0
     bit_size: 2
     array:

--- a/data/registers/gpio_v1.yaml
+++ b/data/registers/gpio_v1.yaml
@@ -258,10 +258,7 @@ fieldset/DESC:
     bit_offset: 16
     bit_size: 16
 fieldset/DIO:
-  # Every one of these registers is a mask over the port's 32 DIO pins, indexed by DIO number.
-  # In the two generic event blocks only one half is implemented: GEN_EVENT0 has DIO0 to DIO15 and
-  # GEN_EVENT1 has DIO16 to DIO31, each at the bit matching its own DIO number.
-  description: A mask over the port's DIO pins.
+  description: 'A mask over the port''s 32 DIO pins, indexed by DIO number. The two generic event blocks implement one half each: GEN_EVENT0 has DIO0 to DIO15 and GEN_EVENT1 has DIO16 to DIO31, each at the bit matching its own DIO number.'
   fields:
   - name: DIO
     description: One bit per DIO pin.

--- a/data/registers/gpio_v1.yaml
+++ b/data/registers/gpio_v1.yaml
@@ -422,14 +422,17 @@ fieldset/FPORT:
     bit_offset: 0
     bit_size: 4
 fieldset/GEN_EVENT:
-  description: Interrupt clear.
+  # Indexed by absolute DIO number, so that it agrees with CPU_INT and the DOUT/DIN masks.
+  # GEN_EVENT0 implements DIO0 to DIO15 and GEN_EVENT1 implements DIO16 to DIO31, each at the bit
+  # matching its own DIO number; the other half of the word is reserved in both.
+  description: Generic event mask, one bit per DIO.
   fields:
   - name: DIO
-    description: DIO0 event.
+    description: DIO event.
     bit_offset: 0
     bit_size: 1
     array:
-      len: 16
+      len: 32
       stride: 1
 fieldset/GEN_EVENT_IIDX:
   description: Interrupt index.

--- a/data/registers/i2c_v1.yaml
+++ b/data/registers/i2c_v1.yaml
@@ -43,16 +43,16 @@ block/CONTROLLER:
     description: I2C Controller FIFO Status Register.
     byte_offset: 44
     access: Read
-    fieldset: CFIFOSR
+    fieldset: FIFOSR
   - name: CONTROLLER_I2CPECCTL
     description: I2C Controller PEC control register.
     byte_offset: 48
-    fieldset: CONTROLLER_I2CPECCTL
+    fieldset: PECCTL
   - name: CONTROLLER_PECSR
     description: I2C Controller PEC status register.
     byte_offset: 52
     access: Read
-    fieldset: CONTROLLER_PECSR
+    fieldset: PECSR
 block/CPU_INT:
   items:
   - name: IIDX
@@ -252,16 +252,16 @@ block/TARGET:
     description: I2C Target FIFO Status Register.
     byte_offset: 32
     access: Read
-    fieldset: TFIFOSR
+    fieldset: FIFOSR
   - name: TARGET_PECCTL
     description: I2C Target PEC control register.
     byte_offset: 36
-    fieldset: TARGET_PECCTL
+    fieldset: PECCTL
   - name: TARGET_PECSR
     description: I2C Target PEC status register.
     byte_offset: 40
     access: Read
-    fieldset: TARGET_PECSR
+    fieldset: PECSR
 fieldset/CBMON:
   description: I2C Controller Bus Monitor.
   fields:
@@ -344,8 +344,8 @@ fieldset/CFIFOCTL:
     description: RX FIFO Flush Setting this bit will Flush the RX FIFO. Before clearing this bit to stop Flush the RXFIFOCNT should be checked to be 0 and indicating that the Flush has completed.
     bit_offset: 15
     bit_size: 1
-fieldset/CFIFOSR:
-  description: I2C Controller FIFO Status Register.
+fieldset/FIFOSR:
+  description: I2C FIFO Status Register.
   fields:
   - name: RXFIFOCNT
     description: Number of Bytes which could be read from the RX FIFO.
@@ -394,8 +394,8 @@ fieldset/CLKSEL:
     description: Selects BUSCLK as clock source if enabled.
     bit_offset: 3
     bit_size: 1
-fieldset/CONTROLLER_I2CPECCTL:
-  description: I2C Controller PEC control register.
+fieldset/PECCTL:
+  description: I2C PEC control register.
   fields:
   - name: PECCNT
     description: PEC Count When this field is non zero, the number of I2C bytes are counted (Note that although the PEC is calculated on the I2C address it is not counted at a byte). When the byte count = PECCNT and the state machine is transmitting, the contents of the LSFR is loaded into the shift register instead of the byte received from the Tx FIFO. When the state machine is receiving, after the last bit of this byte is received the LSFR is checked and if it is non-zero, a PEC RX Error interrupt is generated. The I2C packet must be padded to include the PEC byte for both transmit and receive. In transmit mode the FIFO must be loaded with a dummy PEC byte. In receive mode the PEC byte will be passed to the Rx FIFO. In the normal Controller use case, FW would set PECEN=1 and PECCNT=SMB packet length (Not including Target Address byte, but including the PEC byte). FW would then configure DMA to allow the packet to complete unassisted and write MCTR to initiate the transaction. Note that when the byte count = PEC CNT, the byte count is reset to 0 and multiple PEC calculation can automatically occur within a single I2C transaction. Note that any write to the Controller_I2CPECCTL Register will clear the current PEC Byte Count in the Controller State Machine.
@@ -405,8 +405,8 @@ fieldset/CONTROLLER_I2CPECCTL:
     description: PEC Enable This bit enables the SMB Packet Error Checking (PEC). When enabled the PEC is calculated on all bits except the Start, Stop, Ack and Nack. The PEC LSFR and the Byte Counter is set to 0 when the State Machine is in the IDLE state, which occur following a Stop or when a timeout occurs. The Counter is also set to 0 after the PEC byte is sent or received. Note that the NACK is automatically send following a PEC byte that results in a PEC error. The PEC Polynomial is x^8 + x^2 + x^1 + 1.
     bit_offset: 12
     bit_size: 1
-fieldset/CONTROLLER_PECSR:
-  description: I2C Controller PEC status register.
+fieldset/PECSR:
+  description: I2C PEC status register.
   fields:
   - name: PECBYTECNT
     description: PEC Byte Count. This is the current PEC Byte Count of the Controller State Machine.
@@ -794,32 +794,6 @@ fieldset/TACKCTL:
     description: When set this bit will automatically turn on the Target ACKOEN field following the ACK/NACK of the received PEC byte.
     bit_offset: 4
     bit_size: 1
-fieldset/TARGET_PECCTL:
-  description: I2C Target PEC control register.
-  fields:
-  - name: PECCNT
-    description: When this field is non zero, the number of I2C data bytes are counted. When the byte count = PECCNT and the state machine is transmitting, the contents of the LSFR is loaded into the shift register instead of the byte received from the Tx FIFO. When the state machine is receiving, after the last bit of this byte is received the LSFR is checked and if it is non-zero, a PEC RX Error interrupt is generated. The I2C packet must be padded to include the PEC byte for both transmit and receive. In transmit mode the FIFO must be loaded with a dummy PEC byte. In receive mode the PEC byte will be passed to the Rx FIFO. In the normal Target use case, FW would set PECEN=1 and PECCNT=0 and use the ACKOEN until the remaining SMB packet length is known. FW would then set the PECCNT to the remaining packet length (Including PEC bye). FW would then configure DMA to allow the packet to complete unassisted and exit NoAck mode. Note that when the byte count = PEC CNT, the byte count is reset to 0 and multiple PEC calculation can automatically occur within a single I2C transaction.
-    bit_offset: 0
-    bit_size: 9
-  - name: PECEN
-    description: PEC Enable This bit enables the SMB Packet Error Checking (PEC). When enabled the PEC is calculated on all bits except the Start, Stop, Ack and Nack. The PEC LSFR and the Byte Counter is set to 0 when the State Machine is in the IDLE state, which occur following a Stop or when a timeout occurs. The Counter is also set to 0 after the PEC byte is sent or received. Note that the NACK is automatically send following a PEC byte that results in a PEC error. The PEC Polynomial is x^8 + x^2 + x^1 + 1.
-    bit_offset: 12
-    bit_size: 1
-fieldset/TARGET_PECSR:
-  description: I2C Target PEC status register.
-  fields:
-  - name: PECBYTECNT
-    description: This is the current PEC Byte Count of the Target State Machine.
-    bit_offset: 0
-    bit_size: 9
-  - name: PECSTS_CHECK
-    description: This status bit indicates if the PEC was checked in the transaction that occurred before the last Stop. Latched on Stop.
-    bit_offset: 16
-    bit_size: 1
-  - name: PECSTS_ERROR
-    description: This status bit indicates if a PEC check error occurred in the transaction that occurred before the last Stop. Latched on Stop.
-    bit_offset: 17
-    bit_size: 1
 fieldset/TCTR:
   description: I2C Target Control Register.
   fields:
@@ -886,25 +860,6 @@ fieldset/TFIFOCTL:
     enum: TFIFOCTL_RXTRIG
   - name: RXFLUSH
     description: RX FIFO Flush Setting this bit will Flush the RX FIFO. Before clearing this bit to stop Flush the RXFIFOCNT should be checked to be 0 and indicating that the Flush has completed.
-    bit_offset: 15
-    bit_size: 1
-fieldset/TFIFOSR:
-  description: I2C Target FIFO Status Register.
-  fields:
-  - name: RXFIFOCNT
-    description: Number of Bytes which could be read from the RX FIFO.
-    bit_offset: 0
-    bit_size: 4
-  - name: RXFLUSH
-    description: RX FIFO Flush When this bit is set a Flush operation for the RX FIFO is active. Clear the RXFLUSH bit in the control register to stop.
-    bit_offset: 7
-    bit_size: 1
-  - name: TXFIFOCNT
-    description: Number of Bytes which could be put into the TX FIFO.
-    bit_offset: 8
-    bit_size: 4
-  - name: TXFLUSH
-    description: TX FIFO Flush When this bit is set a Flush operation for the TX FIFO is active. Clear the TXFLUSH bit in the control register to stop.
     bit_offset: 15
     bit_size: 1
 fieldset/TIMEOUT_CNT:

--- a/data/registers/iomux_v1.yaml
+++ b/data/registers/iomux_v1.yaml
@@ -2,8 +2,7 @@ block/IOMUX:
   description: PERIPHERALREGION.
   items:
   - name: PINCM
-    description: Pin Control Management Register in SECCFG region.
-    # Note: the HAL is responsible for checking entry in the PINCM array is valid to access.
+    description: Pin Control Management Register in SECCFG region. The array is sized for the largest device, so the caller is responsible for checking that an entry exists on the chip in hand before accessing it.
     array:
       len: 251
       stride: 4

--- a/data/registers/mathacl_v1.yaml
+++ b/data/registers/mathacl_v1.yaml
@@ -30,19 +30,15 @@ block/MATHACL:
   - name: OP2
     description: Operand 2 register.
     byte_offset: 4376
-    fieldset: OP2
   - name: OP1
     description: Operand 1 register.
     byte_offset: 4380
-    fieldset: OP1
   - name: RES1
     description: Result 1 register.
     byte_offset: 4384
-    fieldset: RES1
   - name: RES2
     description: Result 2 register.
     byte_offset: 4388
-    fieldset: RES2
   - name: STATUS
     description: Status Register.
     byte_offset: 4400
@@ -82,20 +78,6 @@ fieldset/CTL:
     description: 'Number of iterations, applicable if the function does the computations iteratively, for example sine/cosine/atan2/sqrt. Note: A value of 0 is interpreted as 31.'
     bit_offset: 24
     bit_size: 5
-fieldset/OP1:
-  description: Operand 1 register.
-  fields:
-  - name: DATA
-    description: Operand 1 Register
-    bit_offset: 0
-    bit_size: 32
-fieldset/OP2:
-  description: Operand 2 register.
-  fields:
-  - name: DATA
-    description: Operand 1 Register
-    bit_offset: 0
-    bit_size: 32
 fieldset/PWREN:
   description: Power enable.
   fields:
@@ -108,20 +90,6 @@ fieldset/PWREN:
     bit_offset: 24
     bit_size: 8
     enum: PWREN_KEY
-fieldset/RES1:
-  description: Result 1 register.
-  fields:
-  - name: DATA
-    description: Result 1 Register
-    bit_offset: 0
-    bit_size: 32
-fieldset/RES2:
-  description: Result 2 register.
-  fields:
-  - name: DATA
-    description: Result 2 Register
-    bit_offset: 0
-    bit_size: 32
 fieldset/RSTCTL:
   description: Reset Control.
   fields:
@@ -129,12 +97,10 @@ fieldset/RSTCTL:
     description: Assert reset to the peripheral.
     bit_offset: 0
     bit_size: 1
-    enum: RESETASSERT
   - name: RESETSTKYCLR
     description: Clear the RESETSTKY bit in the STAT register.
     bit_offset: 1
     bit_size: 1
-    enum: RESETSTKYCLR
   - name: KEY
     description: Unlock key B1h = KEY to allow write access to this register
     bit_offset: 24
@@ -147,7 +113,6 @@ fieldset/STAT:
     description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
     bit_offset: 16
     bit_size: 1
-    enum: RESETSTKY
 fieldset/STATUS:
   description: Status Register.
   fields:
@@ -168,7 +133,6 @@ fieldset/STATUS:
     description: MATHACL busy bit.
     bit_offset: 8
     bit_size: 1
-    enum: BUSY
 fieldset/STATUSCLR:
   description: Status flag clear register.
   fields:
@@ -184,15 +148,6 @@ fieldset/STATUSCLR:
     description: Write 1 to this bit to clear STATUS.ERR field.
     bit_offset: 2
     bit_size: 1
-enum/BUSY:
-  bit_size: 1
-  variants:
-  - name: DONE
-    description: Compute has completed.
-    value: 0
-  - name: NOTDONE
-    description: Compute ongoing.
-    value: 1
 enum/ERR:
   bit_size: 2
   variants:
@@ -342,33 +297,6 @@ enum/QVAL:
   - name: Q31
     description: Q31 operands.
     value: 31
-enum/RESETASSERT:
-  bit_size: 1
-  variants:
-  - name: NOP
-    description: Writing 0 has no effect.
-    value: 0
-  - name: ASSERT
-    description: Assert reset.
-    value: 1
-enum/RESETSTKY:
-  bit_size: 1
-  variants:
-  - name: NORES
-    description: The peripheral has not been reset since this bit was last cleared by RESETSTKYCLR in the RSTCTL register.
-    value: 0
-  - name: RESET
-    description: The peripheral was reset since the last bit clear.
-    value: 1
-enum/RESETSTKYCLR:
-  bit_size: 1
-  variants:
-  - name: NOP
-    description: Writing 0 has no effect.
-    value: 0
-  - name: CLR
-    description: Clear reset sticky bit.
-    value: 1
 enum/RESET_KEY:
   bit_size: 8
   variants:

--- a/data/registers/sysctl_c1105_c1106.yaml
+++ b/data/registers/sysctl_c1105_c1106.yaml
@@ -349,7 +349,7 @@ fieldset/GENCLKEN:
     bit_offset: 0
     bit_size: 1
   - name: MFPCLKEN
-    description: Enable the MFCLK.
+    description: Enable the MFPCLK.
     bit_offset: 4
     bit_size: 1
 fieldset/HFCLKCLKCFG:
@@ -734,7 +734,7 @@ enum/EXCLKSRC:
     value: 1
   - name: LFCLK
     value: 2
-  - name: MFCLK
+  - name: MFPCLK
     description: 'NOTE: This must be divided in post divider.'
     value: 3
   - name: HFCLK

--- a/data/registers/sysctl_c1105_c1106.yaml
+++ b/data/registers/sysctl_c1105_c1106.yaml
@@ -261,8 +261,6 @@ fieldset/EXLFCTL:
   fields:
   - name: SETUSEEXLF
     description: Use external LF CLK IN.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY
@@ -274,8 +272,6 @@ fieldset/EXRSTPIN:
   fields:
   - name: DISABLE
     description: Disable External Reset.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY
@@ -636,8 +632,6 @@ fieldset/SYSSTATUSCLR:
   fields:
   - name: ALLECC
     description: Clear ALL ECC related SYSSTATUS indicators.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY

--- a/data/registers/sysctl_c1105_c1106.yaml
+++ b/data/registers/sysctl_c1105_c1106.yaml
@@ -1,0 +1,988 @@
+block/SYSCTL:
+  description: SYSCTL.
+  items:
+  - name: IIDX
+    description: Event IIDX.
+    byte_offset: 4128
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Event IMASK.
+    byte_offset: 4136
+    fieldset: INT
+  - name: RIS
+    description: Event RIS.
+    byte_offset: 4144
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Event MIS.
+    byte_offset: 4152
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Event ISET.
+    byte_offset: 4160
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Event ICLR.
+    byte_offset: 4168
+    access: Write
+    fieldset: INT
+  - name: NMI_IIDX
+    byte_offset: 4176
+    fieldset: NMI_IIDX
+  - name: NMI_RIS
+    byte_offset: 4192
+    fieldset: NMI
+  - name: NMI_ISET
+    byte_offset: 4208
+    fieldset: NMI
+  - name: NMI_ICLR
+    byte_offset: 4216
+    fieldset: NMI
+  - name: SYSOSCCFG
+    description: SYSOSC Configuration.
+    byte_offset: 4352
+    fieldset: SYSOSCCFG
+  - name: MCLKCFG
+    description: Configuration related to MCLK.
+    byte_offset: 4356
+    fieldset: MCLKCFG
+  - name: HSCLKEN
+    description: High Speed Clock Configuration.
+    byte_offset: 4360
+    fieldset: HSCLKEN
+  - name: HSCLKCFG
+    description: High Speed Clock Source Selection.
+    byte_offset: 4364
+    fieldset: HSCLKCFG
+  - name: HFCLKCLKCFG
+    description: HFCLK Clock Configuration.
+    byte_offset: 4368
+    fieldset: HFCLKCLKCFG
+  - name: LFCLKCFG
+    description: LFCLK Clock Configuration.
+    byte_offset: 4372
+    fieldset: LFCLKCFG
+  - name: GENCLKCFG
+    description: General Clock Configuration.
+    byte_offset: 4408
+    fieldset: GENCLKCFG
+  - name: GENCLKEN
+    description: General Clock Enables.
+    byte_offset: 4412
+    fieldset: GENCLKEN
+  - name: PMODECFG
+    description: Power Mode Configurations.
+    byte_offset: 4416
+    fieldset: PMODECFG
+  - name: FCC
+    byte_offset: 4432
+    fieldset: FCC
+  - name: SRAMBOUNDARY
+    byte_offset: 4472
+    fieldset: SRAMBOUNDARY
+  - name: SYSTEMCFG
+    description: SRAM Write Protect.
+    byte_offset: 4480
+    fieldset: SYSTEMCFG
+  - name: WRITELOCK
+    description: SYSOSC Trim Values specified by user.
+    byte_offset: 4608
+    fieldset: WRITELOCK
+  - name: CLKSTATUS
+    description: Useful debug status of clock selections.
+    byte_offset: 4612
+    access: Read
+    fieldset: CLKSTATUS
+  - name: SYSSTATUS
+    description: Useful System Status Data.
+    byte_offset: 4616
+    access: Read
+    fieldset: SYSSTATUS
+  - name: RSTCAUSE
+    byte_offset: 4640
+    fieldset: RSTCAUSE
+  - name: RESETLEVEL
+    description: Reset Level for Application Reset Command.
+    byte_offset: 4864
+    fieldset: RESETLEVEL
+  - name: RESETCMD
+    description: Execute Reset Command.
+    byte_offset: 4868
+    access: Write
+    fieldset: RESETCMD
+  - name: BORTHRESHOLD
+    description: BOR Threshold Level.
+    byte_offset: 4872
+    fieldset: BORTHRESHOLD
+  - name: BORCLRCMD
+    byte_offset: 4876
+    fieldset: BORCLRCMD
+  - name: SYSOSCFCLCTL
+    description: SYSOSC Frequency Control Loop with External Resistor.
+    byte_offset: 4880
+    access: Write
+    fieldset: SYSOSCFCLCTL
+  - name: LFXTCTL
+    description: LFXT Control -- Only BOR Level Reset will clear.
+    byte_offset: 4884
+    access: Write
+    fieldset: LFXTCTL
+  - name: EXLFCTL
+    description: EX LF Control -- Only BOR Level Reset will clear.
+    byte_offset: 4888
+    access: Write
+    fieldset: EXLFCTL
+  - name: SHDNIOREL
+    description: Shutdown IO Release Command.
+    byte_offset: 4892
+    access: Write
+    fieldset: SHDNIOREL
+  - name: EXRSTPIN
+    description: Disable use of external Reset Pin.
+    byte_offset: 4896
+    access: Write
+    fieldset: EXRSTPIN
+  - name: SYSSTATUSCLR
+    description: Clear sticky bits of SYSSTATUS.
+    byte_offset: 4900
+    access: Write
+    fieldset: SYSSTATUSCLR
+  - name: SWDCFG
+    description: Disable SWD.
+    byte_offset: 4904
+    access: Write
+    fieldset: SWDCFG
+  - name: FCCCMD
+    byte_offset: 4908
+    fieldset: FCCCMD
+  - name: SHUTDNSTORE
+    description: Shutdown Storage Byte 0.
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 5120
+    fieldset: SHUTDNSTORE
+fieldset/BORCLRCMD:
+  fields:
+  - name: GO
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: BORCLRCMD_KEY
+fieldset/BORTHRESHOLD:
+  description: BOR Threshold Level.
+  fields:
+  - name: LEVEL
+    description: 'BOR Threshold Level 0: Full Re-boot This level is always enforced regardless of MMR seting 1-3: Generates interrupt.'
+    bit_offset: 0
+    bit_size: 2
+fieldset/CLKSTATUS:
+  description: Useful debug status of clock selections.
+  fields:
+  - name: SYSOSCFREQ
+    description: Current SYSOSC frequency setting.
+    bit_offset: 0
+    bit_size: 2
+    enum: SYSOSCFREQ
+  - name: HSCLKMUX
+    description: High Speed Clock Selected for MCLK (HFCLK, PLL,...).
+    bit_offset: 4
+    bit_size: 1
+    enum: HSCLKMUX
+  - name: LFCLKMUX
+    description: Low Frequency Clock Selected.
+    bit_offset: 6
+    bit_size: 2
+    enum: LFCLKMUX
+  - name: LFOSCGOOD
+    description: LFOSC is Valid.
+    bit_offset: 11
+    bit_size: 1
+  - name: HFCLKGOOD
+    description: HFCLK started correctly.
+    bit_offset: 8
+    bit_size: 1
+  - name: LFXTGOOD
+    description: LFXT started correctly.
+    bit_offset: 10
+    bit_size: 1
+  - name: HSCLKSOFF
+    description: All PLLs, HFCLKs are OFF or DEAD.
+    bit_offset: 12
+    bit_size: 1
+  - name: HFCLKOFF
+    description: HFCLKs is OFF or DEAD.
+    bit_offset: 13
+    bit_size: 1
+  - name: CURHSCLKSEL
+    description: Current HSCLK source, matching HSCLKCFG.HSCLKSEL.
+    bit_offset: 16
+    bit_size: 1
+    enum: HSCLKSEL
+  - name: CURMCLKSEL
+    description: 'MCLK Clock Source 0: NOT LFCLK, 1:LFCLK.'
+    bit_offset: 17
+    bit_size: 1
+  - name: HSCLKDEAD
+    description: The HSCLK source did not start correctly.
+    bit_offset: 20
+    bit_size: 1
+  - name: HSCLKGOOD
+    description: The HSCLK source started correctly.
+    bit_offset: 21
+    bit_size: 1
+  - name: LFCLKFAIL
+    description: The continuous LFCLK monitor detected a stuck fault.
+    bit_offset: 23
+    bit_size: 1
+  - name: FCLMODE
+    description: SYSOSC FCL MODE ON.
+    bit_offset: 24
+    bit_size: 1
+  - name: HFCLKBLKUPD
+    description: Writes to HFCLKCLKCFG are blocked.
+    bit_offset: 28
+    bit_size: 1
+  - name: FCCDONE
+    bit_offset: 25
+    bit_size: 1
+  - name: ANACLKERR
+    description: Error with Anacomp High Speed CP Clock Generation - SYSOSC must not run at 4MHz.
+    bit_offset: 31
+    bit_size: 1
+fieldset/EXLFCTL:
+  description: EX LF Control -- Only BOR Level Reset will clear.
+  fields:
+  - name: SETUSEEXLF
+    description: Use external LF CLK IN.
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: EXLFCTL_KEY
+fieldset/EXRSTPIN:
+  description: Disable use of external Reset Pin.
+  fields:
+  - name: DISABLE
+    description: Disable External Reset.
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: EXRSTPIN_KEY
+fieldset/FCC:
+  fields:
+  - name: DATA
+    bit_offset: 0
+    bit_size: 22
+fieldset/FCCCMD:
+  fields:
+  - name: GO
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: FCCCMD_KEY
+fieldset/GENCLKCFG:
+  description: General Clock Configuration.
+  fields:
+  - name: EXCLKSRC
+    description: External Clock Source Select.
+    bit_offset: 0
+    bit_size: 3
+    enum: EXCLKSRC
+  - name: EXCLKDIVVAL
+    bit_offset: 4
+    bit_size: 3
+    enum: EXCLKDIVVAL
+  - name: EXCLKDIVEN
+    description: '1: Enable divide 0: Pass Src Clock Through.'
+    bit_offset: 7
+    bit_size: 1
+  - name: MFPCLKSRC
+    description: Source for MFPCLK Clock.
+    bit_offset: 9
+    bit_size: 1
+    enum: MFPCLKSRC
+  - name: HFCLK4MFPCLKDIV
+    description: HFCLK Divider 1..16.
+    bit_offset: 12
+    bit_size: 4
+  - name: FCCSELCLK
+    bit_offset: 16
+    bit_size: 4
+    enum: FCCSELCLK
+  - name: FCCTRIGSRC
+    bit_offset: 20
+    bit_size: 1
+    enum: FCCTRIGSRC
+  - name: FCCLVLTRIG
+    bit_offset: 21
+    bit_size: 1
+    enum: FCCLVLTRIG
+  - name: ANACPUMPCFG
+    bit_offset: 22
+    bit_size: 2
+    enum: ANACPUMPCFG
+  - name: FCCTRIGCNT
+    bit_offset: 24
+    bit_size: 5
+  - name: FCCLFCLKSRC
+    description: Select between the system LFCLK and the external LFCLK for the FCC.
+    bit_offset: 29
+    bit_size: 1
+fieldset/GENCLKEN:
+  description: General Clock Enables.
+  fields:
+  - name: EXCLKEN
+    description: Enable the External Clock Output.
+    bit_offset: 0
+    bit_size: 1
+  - name: MFPCLKEN
+    description: Enable the MFCLK.
+    bit_offset: 4
+    bit_size: 1
+fieldset/HFCLKCLKCFG:
+  description: HFCLK Clock Configuration.
+  fields:
+  - name: HFXTTIME
+    description: HFXT startup time in 64us resolution.
+    bit_offset: 0
+    bit_size: 8
+  - name: HFXTRSEL
+    description: HFXT range select, which must match the crystal's frequency.
+    bit_offset: 12
+    bit_size: 2
+    enum: HFXTRSEL
+  - name: HFCLKFLTCHK
+    description: Enables the HFCLK startup monitor.
+    bit_offset: 28
+    bit_size: 1
+fieldset/HSCLKCFG:
+  description: High Speed Clock Source Selection.
+  fields:
+  - name: HSCLKSEL
+    description: Selects the HSCLK source.
+    bit_offset: 0
+    bit_size: 1
+    enum: HSCLKSEL
+fieldset/HSCLKEN:
+  description: High Speed Clock Configuration.
+  fields:
+  - name: HFXTEN
+    description: HFXTEN enables or disables the high frequency crystal oscillator (HFXT).
+    bit_offset: 0
+    bit_size: 1
+  - name: USEEXTHFCLK
+    description: Use External Pin as High Frequency Oscillator Source(HFCLK).
+    bit_offset: 16
+    bit_size: 1
+fieldset/IIDX:
+  description: Event IIDX.
+  fields:
+  - name: STAT
+    description: Interrupt Index Register -- Read Only.
+    bit_offset: 0
+    bit_size: 4
+    enum: STAT
+fieldset/INT:
+  description: Event ICLR.
+  fields:
+  - name: LFOSCGOOD
+    description: LFOSC GOOD.
+    bit_offset: 0
+    bit_size: 1
+  - name: ANACLKERR
+    bit_offset: 1
+    bit_size: 1
+  - name: LFXTGOOD
+    description: LFXT GOOD.
+    bit_offset: 2
+    bit_size: 1
+  - name: HFCLKGOOD
+    description: HFCLK GOOD.
+    bit_offset: 3
+    bit_size: 1
+  - name: HSCLKGOOD
+    description: HSCLK GOOD.
+    bit_offset: 4
+    bit_size: 1
+fieldset/LFCLKCFG:
+  description: LFCLK Clock Configuration.
+  fields:
+  - name: XT1DRIVE
+    description: LFXT drive strength.
+    bit_offset: 0
+    bit_size: 2
+    enum: XT1DRIVE
+  - name: MONITOR
+    description: Enables the LFCLK monitor.
+    bit_offset: 4
+    bit_size: 1
+  - name: LOWCAP
+    description: Enables LFXT low capacitance mode, for a load capacitance under 3pF.
+    bit_offset: 8
+    bit_size: 1
+fieldset/LFXTCTL:
+  description: LFXT Control.
+  fields:
+  - name: STARTLFXT
+    description: Set to start the low frequency crystal oscillator. Remains set until the next BOR level reset.
+    bit_offset: 0
+    bit_size: 1
+  - name: SETUSELFXT
+    description: Set to switch LFCLK to LFXT. Once set, SETUSELFXT remains set until the next BOR level reset.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: LFXTCTL_KEY
+fieldset/MCLKCFG:
+  description: Configuration related to MCLK.
+  fields:
+  - name: MDIV
+    description: MDIV Divider 1..16 when RUN-SLEEP.
+    bit_offset: 0
+    bit_size: 4
+  - name: FLASHWAIT
+    description: FLASHWAIT specifies the number of flash wait states when MCLK is sourced from HSCLK. FLASHWAIT has no effect when MCLK is sourced from SYSOSC or LFCLK.
+    bit_offset: 8
+    bit_size: 4
+    enum: FLASHWAIT
+  - name: USEMFTICK
+    description: USE the MFTICK feature (this will limit MDIV options).
+    bit_offset: 12
+    bit_size: 1
+  - name: USEHSCLK
+    description: High Speed Clock Selected for MCLK (HFCLK, PLL,...).
+    bit_offset: 16
+    bit_size: 1
+  - name: USELFCLK
+    description: Low Frequency Clock Selected for MCLK.
+    bit_offset: 20
+    bit_size: 1
+  - name: STOPCLKSTBY
+    description: STOP ULPCLK Root during STANDBY, Only wake on ASYNC IO Events.
+    bit_offset: 21
+    bit_size: 1
+  - name: MCLKDEADCHK
+    bit_offset: 22
+    bit_size: 1
+fieldset/NMI:
+  fields:
+  - name: BORLVL
+    bit_offset: 0
+    bit_size: 1
+  - name: WWDT0
+    bit_offset: 1
+    bit_size: 1
+  - name: LFCLKFAIL
+    description: LFXT or EXLF monitor fault.
+    bit_offset: 2
+    bit_size: 1
+fieldset/NMI_IIDX:
+  fields:
+  - name: STAT
+    bit_offset: 0
+    bit_size: 3
+    enum: NMI_STAT
+fieldset/PMODECFG:
+  description: Power Mode Configurations.
+  fields:
+  - name: DSLEEP
+    description: 'Action to be taken on DEEPSLEEP 0: STOP, 1:STANDBY, 2: SHUTDOWN 3: Reserved.'
+    bit_offset: 0
+    bit_size: 2
+    enum: DSLEEP
+fieldset/RESETCMD:
+  description: Execute Reset Command.
+  fields:
+  - name: GO
+    description: Execute Reset defined in RESETLEVEL.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: RESETCMD_KEY
+fieldset/RESETLEVEL:
+  description: Reset Level for Application Reset Command.
+  fields:
+  - name: LEVEL
+    description: 'Reset Level 0: CPU plus peripherals, 1: BOR level reset to BOOTCODE, 2: Do CPU plus Peripheral reset then BOOTLOADER, 3: Full Power On Reset -- vcore disabled.'
+    bit_offset: 0
+    bit_size: 2
+    enum: RESETLEVEL_LEVEL
+fieldset/RSTCAUSE:
+  fields:
+  - name: ID
+    bit_offset: 0
+    bit_size: 5
+    enum: ID
+fieldset/SHDNIOREL:
+  description: Shutdown IO Release Command.
+  fields:
+  - name: RELEASE
+    description: Release IO after Shutdown.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SHDNIOREL_KEY
+fieldset/SHUTDNSTORE:
+  description: Shutdown Storage Byte 0.
+  fields:
+  - name: DATA
+    description: Shutdown Storage Byte 0.
+    bit_offset: 0
+    bit_size: 8
+fieldset/SRAMBOUNDARY:
+  description: SRAM Write Boundary
+  fields:
+  - name: ADDR
+    bit_offset: 5
+    bit_size: 15
+fieldset/SWDCFG:
+  description: Disable SWD.
+  fields:
+  - name: DISABLE
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SWDCFG_KEY
+fieldset/SYSOSCCFG:
+  description: SYSOSC Configuration.
+  fields:
+  - name: FREQ
+    description: 'Freq Target: 0: BASE 1: 4M 2: USER 3: Reserved for Turbo 48MHz.'
+    bit_offset: 0
+    bit_size: 2
+    enum: SYSOSCCFG_FREQ
+  - name: DISABLESTOP
+    description: Disable SYSOSC when in STOP mode to allow STOP with LFCLK.
+    bit_offset: 9
+    bit_size: 1
+  - name: DISABLE
+    description: Disable SYSOSC to run all power modes with LFCLK.
+    bit_offset: 10
+    bit_size: 1
+  - name: BLOCKASYNCALL
+    description: Block all async requests from enabling SYSOSC via hardware, ie keep running from LFCLK.
+    bit_offset: 16
+    bit_size: 1
+  - name: FASTCPUEVENT
+    description: Block all UART async requests from enabling SYSOSC via hardware, ie keep running from LFCLK if UART is requester.
+    bit_offset: 17
+    bit_size: 1
+fieldset/SYSOSCFCLCTL:
+  description: SYSOSC Frequency Control Loop with External Resistor.
+  fields:
+  - name: SETUSEFCL
+    description: Use Freq Control Loop.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SYSOSCFCLCTL_KEY
+fieldset/SYSSTATUS:
+  fields:
+  - name: BORCURTHRESHOLD
+    bit_offset: 2
+    bit_size: 2
+  - name: BORLVL
+    bit_offset: 4
+    bit_size: 1
+  - name: ANACPUMPGOOD
+    bit_offset: 5
+    bit_size: 1
+  - name: PMUIREFGOOD
+    bit_offset: 6
+    bit_size: 1
+  - name: EXTRSTPINDIS
+    bit_offset: 12
+    bit_size: 1
+  - name: SWDCFGDIS
+    bit_offset: 13
+    bit_size: 1
+  - name: SHDNIOLOCK
+    bit_offset: 14
+    bit_size: 1
+  - name: REBOOTATTEMPTS
+    bit_offset: 30
+    bit_size: 2
+fieldset/SYSSTATUSCLR:
+  description: Clear sticky bits of SYSSTATUS.
+  fields:
+  - name: ALLECC
+    description: Clear ALL ECC related SYSSTATUS indicators.
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SYSSTATUSCLR_KEY
+fieldset/SYSTEMCFG:
+  description: System configuration
+  fields:
+  - name: WWDTLP0RSTDIS
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SYSTEMCFG_KEY
+fieldset/WRITELOCK:
+  description: SYSOSC Trim Values specified by user.
+  fields:
+  - name: ACTIVE
+    description: LOCK configuration MMRs from write.
+    bit_offset: 0
+    bit_size: 1
+enum/ANACPUMPCFG:
+  bit_size: 2
+  variants:
+  - name: ONDEMAND
+    description: VBOOST is enabled on request from a COMP, GPAMP, or OPA.
+    value: 0
+  - name: ONACTIVE
+    description: VBOOST is enabled when the device is in RUN or SLEEP mode, or when a COMP/GPAMP/OPA is enabled.
+    value: 1
+  - name: ONALWAYS
+    description: VBOOST is always enabled.
+    value: 2
+enum/BORCLRCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 199
+enum/DSLEEP:
+  bit_size: 2
+  variants:
+  - name: STOP
+    value: 0
+  - name: STANDBY
+    value: 1
+  - name: SHUTDOWN
+    value: 2
+enum/EXCLKDIVVAL:
+  bit_size: 3
+  variants:
+  - name: DIV2
+    value: 0
+  - name: DIV4
+    value: 1
+  - name: DIV6
+    value: 2
+  - name: DIV8
+    value: 3
+  - name: DIV10
+    value: 4
+  - name: DIV12
+    value: 5
+  - name: DIV14
+    value: 6
+  - name: DIV16
+    value: 7
+enum/EXCLKSRC:
+  bit_size: 3
+  variants:
+  - name: SYSOSC
+    value: 0
+  - name: ULPCLK
+    description: 'NOTE: This must be divided in post divider.'
+    value: 1
+  - name: LFCLK
+    value: 2
+  - name: MFCLK
+    description: 'NOTE: This must be divided in post divider.'
+    value: 3
+  - name: HFCLK
+    value: 4
+  - name: SYSPLLOUT1
+    description: 'NOTE: Must be 48MHz or below.'
+    value: 5
+enum/EXLFCTL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 54
+enum/EXRSTPIN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 30
+enum/FCCCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 14
+enum/FCCLVLTRIG:
+  bit_size: 1
+  variants:
+  - name: RISING
+    value: 0
+  - name: LEVEL
+    value: 1
+enum/FCCSELCLK:
+  bit_size: 4
+  variants:
+  - name: MCLK
+    value: 0
+  - name: SYSOSC
+    value: 1
+  - name: HFCLK
+    value: 2
+  - name: CLK_OUT
+    value: 3
+  - name: FCCIN
+    value: 7
+enum/FCCTRIGSRC:
+  bit_size: 1
+  variants:
+  - name: EXTERNAL
+    value: 0
+  - name: LFCLK
+    value: 1
+enum/FLASHWAIT:
+  bit_size: 4
+  variants:
+  - name: WAIT0
+    description: No flash wait states are applied.
+    value: 0
+  - name: WAIT1
+    description: One flash wait state is applied.
+    value: 1
+  - name: WAIT2
+    description: 2 flash wait states are applied.
+    value: 2
+enum/HFXTRSEL:
+  bit_size: 2
+  variants:
+  - name: RANGE4TO8
+    description: 4MHz to 8MHz.
+    value: 0
+  - name: RANGE8TO16
+    description: Above 8MHz to 16MHz.
+    value: 1
+  - name: RANGE16TO32
+    description: Above 16MHz to 32MHz.
+    value: 2
+  - name: RANGE32TO48
+    description: Above 32MHz to 48MHz.
+    value: 3
+enum/HSCLKMUX:
+  bit_size: 1
+  variants:
+  - name: SYSOSC
+    value: 0
+  - name: HSCLK
+    value: 1
+enum/HSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: HSCLK is sourced from the SYSPLL.
+    value: 0
+  - name: HFCLK
+    description: HSCLK is sourced from HFCLK.
+    value: 1
+enum/ID:
+  bit_size: 5
+  variants:
+  - name: NORST
+    description: No reset since last read.
+    value: 0
+  - name: PORHWFAIL
+    description: POR- violation, SHUTDNSTOREx or PMU trim parity fault.
+    value: 1
+  - name: POREXNRST
+    description: NRST triggered POR (&gt;1s hold).
+    value: 2
+  - name: PORSW
+    description: Software triggered POR.
+    value: 3
+  - name: BORSUPPLY
+    description: BOR0- violation.
+    value: 4
+  - name: BORWAKESHUTDN
+    description: SHUTDOWN mode exit.
+    value: 5
+  - name: BOOTCLKFAIL
+    description: Fatal clock failure.
+    value: 9
+  - name: BOOTEXNRST
+    description: NRST triggered BOOTRST (&lt;1s hold).
+    value: 12
+  - name: BOOTSW
+    description: Software triggered BOOTRST.
+    value: 13
+  - name: BOOTWWDT0
+    description: WWDT0 violation.
+    value: 14
+  - name: SYSBSLEXIT
+    description: BSL exit.
+    value: 16
+  - name: SYSBSLENTRY
+    description: BSL entry.
+    value: 17
+  - name: SYSCPULOCK
+    description: CPULOCK violation.
+    value: 21
+  - name: SYSDBG
+    description: Debug triggered SYSRST.
+    value: 26
+  - name: SYSSW
+    description: Software triggered SYSRST.
+    value: 27
+  - name: CPUDBG
+    description: Debug triggered CPURST.
+    value: 28
+  - name: CPUSW
+    description: Software triggered CPURST.
+    value: 29
+enum/LFCLKMUX:
+  bit_size: 2
+  variants:
+  - name: LFOSC
+    description: Internal LFOSC.
+    value: 0
+  - name: LFXT
+    description: LF Crystal.
+    value: 1
+  - name: EXLF
+    description: External LFCLK IN.
+    value: 2
+enum/LFXTCTL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 145
+enum/MFPCLKSRC:
+  bit_size: 1
+  variants:
+  - name: SYSOSC
+    value: 0
+  - name: HFCLK
+    value: 1
+enum/NMI_STAT:
+  bit_size: 3
+  variants:
+  - name: NO_INTR
+    description: No Interrupt.
+    value: 0
+  - name: BORLVL
+    value: 1
+  - name: WWDT0
+    value: 2
+  - name: LFCLKFAIL
+    value: 3
+enum/RESETCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 228
+enum/RESETLEVEL_LEVEL:
+  bit_size: 2
+  variants:
+  - name: CPU
+    description: Reset CPU plus peripherals only.
+    value: 0
+  - name: BOOT
+    description: Reset Main Infrastructure including TRIM.
+    value: 1
+  - name: BOOTLOADER
+    description: Reset Main Infrastructure and Run BOOTLOADER.
+    value: 2
+  - name: POR
+    description: Reset as a Power On Reset.
+    value: 3
+enum/SHDNIOREL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 145
+enum/STAT:
+  bit_size: 4
+  variants:
+  - name: NO_INTR
+    description: No Interrupt.
+    value: 0
+  - name: LFOSCGOOD
+    value: 1
+  - name: ANACLKERR
+    value: 2
+  - name: LFXTGOOD
+    value: 3
+  - name: HFCLKGOOD
+    value: 4
+  - name: HSCLKGOOD
+    value: 5
+enum/SWDCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 98
+enum/XT1DRIVE:
+  bit_size: 2
+  variants:
+  - name: LOWEST
+    value: 0
+  - name: LOWER
+    value: 1
+  - name: HIGHER
+    value: 2
+  - name: HIGHEST
+    value: 3
+enum/SYSOSCCFG_FREQ:
+  bit_size: 2
+  variants:
+  - name: SYSOSCBASE
+    value: 0
+  - name: SYSOSC4M
+    value: 1
+  - name: SYSOSCUSER
+    value: 2
+enum/SYSOSCFCLCTL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 42
+enum/SYSOSCFREQ:
+  bit_size: 2
+  variants:
+  - name: SYSOSC32M
+    value: 0
+  - name: SYSOSC4M
+    value: 1
+  - name: SYSOSCUSER
+    value: 2
+enum/SYSSTATUSCLR_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 206
+enum/SYSTEMCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 27

--- a/data/registers/sysctl_c1105_c1106.yaml
+++ b/data/registers/sysctl_c1105_c1106.yaml
@@ -224,7 +224,7 @@ fieldset/CLKSTATUS:
     description: Current HSCLK source, matching HSCLKCFG.HSCLKSEL.
     bit_offset: 16
     bit_size: 1
-    enum: HSCLKSEL
+    enum: CURHSCLKSEL
   - name: CURMCLKSEL
     description: 'MCLK Clock Source 0: NOT LFCLK, 1:LFCLK.'
     bit_offset: 17
@@ -318,9 +318,10 @@ fieldset/GENCLKCFG:
     bit_size: 1
     enum: MFPCLKSRC
   - name: HFCLK4MFPCLKDIV
-    description: HFCLK Divider 1..16.
+    description: Divider applied to HFCLK when HFCLK is used as the MFPCLK source.
     bit_offset: 12
     bit_size: 4
+    enum: HFCLK4MFPCLKDIV
   - name: FCCSELCLK
     bit_offset: 16
     bit_size: 4
@@ -359,7 +360,7 @@ fieldset/HFCLKCLKCFG:
   description: HFCLK Clock Configuration.
   fields:
   - name: HFXTTIME
-    description: HFXT startup time in 64us resolution.
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
     bit_offset: 0
     bit_size: 8
   - name: HFXTRSEL
@@ -375,7 +376,7 @@ fieldset/HSCLKCFG:
   description: High Speed Clock Source Selection.
   fields:
   - name: HSCLKSEL
-    description: Selects the HSCLK source.
+    description: Selects the HSCLK source. This device has no SYSPLL, so HFCLKCLK is the only source it can select, and software must write it - the reset value leaves HSCLK unsourced.
     bit_offset: 0
     bit_size: 1
     enum: HSCLKSEL
@@ -605,8 +606,10 @@ fieldset/SYSOSCFCLCTL:
 fieldset/SYSSTATUS:
   fields:
   - name: BORCURTHRESHOLD
+    description: Indicates the active brown-out reset supply monitor configuration.
     bit_offset: 2
     bit_size: 2
+    enum: BORCURTHRESHOLD
   - name: BORLVL
     bit_offset: 4
     bit_size: 1
@@ -675,6 +678,30 @@ enum/BORCLRCMD_KEY:
   variants:
   - name: KEY
     value: 199
+enum/BORCURTHRESHOLD:
+  bit_size: 2
+  variants:
+  - name: BORMIN
+    description: Default minimum threshold. A BOR0- violation triggers a BOR.
+    value: 0
+  - name: BORLEVEL1
+    description: A BOR1- violation generates a BORLVL interrupt.
+    value: 1
+  - name: BORLEVEL2
+    description: A BOR2- violation generates a BORLVL interrupt.
+    value: 2
+  - name: BORLEVEL3
+    description: A BOR3- violation generates a BORLVL interrupt.
+    value: 3
+enum/CURHSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: HSCLK is currently sourced from the SYSPLL.
+    value: 0
+  - name: HFCLK
+    description: HSCLK is currently sourced from the HFCLK.
+    value: 1
 enum/DSLEEP:
   bit_size: 2
   variants:
@@ -775,6 +802,57 @@ enum/FLASHWAIT:
   - name: WAIT2
     description: 2 flash wait states are applied.
     value: 2
+enum/HFCLK4MFPCLKDIV:
+  bit_size: 4
+  variants:
+  - name: DIV1
+    description: HFCLK is not divided before being used for MFPCLK.
+    value: 0
+  - name: DIV2
+    description: HFCLK is divided by 2 before being used for MFPCLK.
+    value: 1
+  - name: DIV3
+    description: HFCLK is divided by 3 before being used for MFPCLK.
+    value: 2
+  - name: DIV4
+    description: HFCLK is divided by 4 before being used for MFPCLK.
+    value: 3
+  - name: DIV5
+    description: HFCLK is divided by 5 before being used for MFPCLK.
+    value: 4
+  - name: DIV6
+    description: HFCLK is divided by 6 before being used for MFPCLK.
+    value: 5
+  - name: DIV7
+    description: HFCLK is divided by 7 before being used for MFPCLK.
+    value: 6
+  - name: DIV8
+    description: HFCLK is divided by 8 before being used for MFPCLK.
+    value: 7
+  - name: DIV9
+    description: HFCLK is divided by 9 before being used for MFPCLK.
+    value: 8
+  - name: DIV10
+    description: HFCLK is divided by 10 before being used for MFPCLK.
+    value: 9
+  - name: DIV11
+    description: HFCLK is divided by 11 before being used for MFPCLK.
+    value: 10
+  - name: DIV12
+    description: HFCLK is divided by 12 before being used for MFPCLK.
+    value: 11
+  - name: DIV13
+    description: HFCLK is divided by 13 before being used for MFPCLK.
+    value: 12
+  - name: DIV14
+    description: HFCLK is divided by 14 before being used for MFPCLK.
+    value: 13
+  - name: DIV15
+    description: HFCLK is divided by 15 before being used for MFPCLK.
+    value: 14
+  - name: DIV16
+    description: HFCLK is divided by 16 before being used for MFPCLK.
+    value: 15
 enum/HFXTRSEL:
   bit_size: 2
   variants:
@@ -801,10 +879,10 @@ enum/HSCLKSEL:
   bit_size: 1
   variants:
   - name: SYSPLL
-    description: HSCLK is sourced from the SYSPLL.
+    description: The SYSPLL position of the mux, and the reset value. This device has no SYSPLL, so HSCLK has no source while this is selected.
     value: 0
-  - name: HFCLK
-    description: HSCLK is sourced from HFCLK.
+  - name: HFCLKCLK
+    description: HSCLK is sourced from the HFCLK.
     value: 1
 enum/ID:
   bit_size: 5

--- a/data/registers/sysctl_c110x.yaml
+++ b/data/registers/sysctl_c110x.yaml
@@ -215,7 +215,9 @@ fieldset/EXLFCTL:
   fields:
   - name: SETUSEEXLF
     description: Use external LF CLK IN.
-    bit_offset: 2
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
     bit_size: 1
   - name: KEY
     bit_offset: 24
@@ -226,7 +228,9 @@ fieldset/EXRSTPIN:
   fields:
   - name: DISABLE
     description: Disable External Reset.
-    bit_offset: 2
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
     bit_size: 1
   - name: KEY
     bit_offset: 24
@@ -499,7 +503,9 @@ fieldset/SYSSTATUSCLR:
   fields:
   - name: ALLECC
     description: Clear ALL ECC related SYSSTATUS indicators.
-    bit_offset: 2
+    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
+    # SYSCTL. A write at bit 2 would never take effect.
+    bit_offset: 0
     bit_size: 1
   - name: KEY
     bit_offset: 24

--- a/data/registers/sysctl_c110x.yaml
+++ b/data/registers/sysctl_c110x.yaml
@@ -299,7 +299,7 @@ fieldset/GENCLKEN:
     bit_offset: 0
     bit_size: 1
   - name: MFPCLKEN
-    description: Enable the MFCLK.
+    description: Enable the MFPCLK.
     bit_offset: 4
     bit_size: 1
 fieldset/HSCLKEN:
@@ -595,7 +595,7 @@ enum/EXCLKSRC:
     value: 1
   - name: LFCLK
     value: 2
-  - name: MFCLK
+  - name: MFPCLK
     description: 'NOTE: This must be divided in post divider.'
     value: 3
   - name: HFCLK

--- a/data/registers/sysctl_c110x.yaml
+++ b/data/registers/sysctl_c110x.yaml
@@ -215,8 +215,6 @@ fieldset/EXLFCTL:
   fields:
   - name: SETUSEEXLF
     description: Use external LF CLK IN.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY
@@ -228,8 +226,6 @@ fieldset/EXRSTPIN:
   fields:
   - name: DISABLE
     description: Disable External Reset.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY
@@ -506,8 +502,6 @@ fieldset/SYSSTATUSCLR:
   fields:
   - name: ALLECC
     description: Clear ALL ECC related SYSSTATUS indicators.
-    # The C-series SVD puts this at bit 2, which contradicts SLAU893 and every other family's
-    # SYSCTL. A write at bit 2 would never take effect.
     bit_offset: 0
     bit_size: 1
   - name: KEY

--- a/data/registers/sysctl_c110x.yaml
+++ b/data/registers/sysctl_c110x.yaml
@@ -272,9 +272,10 @@ fieldset/GENCLKCFG:
     bit_size: 1
     enum: MFPCLKSRC
   - name: HFCLK4MFPCLKDIV
-    description: HFCLK Divider 1..16.
+    description: Divider applied to HFCLK when HFCLK is used as the MFPCLK source.
     bit_offset: 12
     bit_size: 4
+    enum: HFCLK4MFPCLKDIV
   - name: FCCSELCLK
     bit_offset: 16
     bit_size: 4
@@ -475,8 +476,10 @@ fieldset/SYSOSCFCLCTL:
 fieldset/SYSSTATUS:
   fields:
   - name: BORCURTHRESHOLD
+    description: Indicates the active brown-out reset supply monitor configuration.
     bit_offset: 2
     bit_size: 2
+    enum: BORCURTHRESHOLD
   - name: BORLVL
     bit_offset: 4
     bit_size: 1
@@ -545,6 +548,21 @@ enum/BORCLRCMD_KEY:
   variants:
   - name: KEY
     value: 199
+enum/BORCURTHRESHOLD:
+  bit_size: 2
+  variants:
+  - name: BORMIN
+    description: Default minimum threshold. A BOR0- violation triggers a BOR.
+    value: 0
+  - name: BORLEVEL1
+    description: A BOR1- violation generates a BORLVL interrupt.
+    value: 1
+  - name: BORLEVEL2
+    description: A BOR2- violation generates a BORLVL interrupt.
+    value: 2
+  - name: BORLEVEL3
+    description: A BOR3- violation generates a BORLVL interrupt.
+    value: 3
 enum/DSLEEP:
   bit_size: 2
   variants:
@@ -633,6 +651,57 @@ enum/FCCTRIGSRC:
     value: 0
   - name: LFCLK
     value: 1
+enum/HFCLK4MFPCLKDIV:
+  bit_size: 4
+  variants:
+  - name: DIV1
+    description: HFCLK is not divided before being used for MFPCLK.
+    value: 0
+  - name: DIV2
+    description: HFCLK is divided by 2 before being used for MFPCLK.
+    value: 1
+  - name: DIV3
+    description: HFCLK is divided by 3 before being used for MFPCLK.
+    value: 2
+  - name: DIV4
+    description: HFCLK is divided by 4 before being used for MFPCLK.
+    value: 3
+  - name: DIV5
+    description: HFCLK is divided by 5 before being used for MFPCLK.
+    value: 4
+  - name: DIV6
+    description: HFCLK is divided by 6 before being used for MFPCLK.
+    value: 5
+  - name: DIV7
+    description: HFCLK is divided by 7 before being used for MFPCLK.
+    value: 6
+  - name: DIV8
+    description: HFCLK is divided by 8 before being used for MFPCLK.
+    value: 7
+  - name: DIV9
+    description: HFCLK is divided by 9 before being used for MFPCLK.
+    value: 8
+  - name: DIV10
+    description: HFCLK is divided by 10 before being used for MFPCLK.
+    value: 9
+  - name: DIV11
+    description: HFCLK is divided by 11 before being used for MFPCLK.
+    value: 10
+  - name: DIV12
+    description: HFCLK is divided by 12 before being used for MFPCLK.
+    value: 11
+  - name: DIV13
+    description: HFCLK is divided by 13 before being used for MFPCLK.
+    value: 12
+  - name: DIV14
+    description: HFCLK is divided by 14 before being used for MFPCLK.
+    value: 13
+  - name: DIV15
+    description: HFCLK is divided by 15 before being used for MFPCLK.
+    value: 14
+  - name: DIV16
+    description: HFCLK is divided by 16 before being used for MFPCLK.
+    value: 15
 enum/HSCLKMUX:
   bit_size: 1
   variants:

--- a/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
+++ b/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
@@ -576,14 +576,13 @@ fieldset/NMI:
     description: Clr the BORLVL NMI.
     bit_offset: 0
     bit_size: 1
-  - name: WWDT0
-    description: Watch Dog 0 Fault.
+  - name: WWDT
+    description: Watch dog fault, one bit per WWDT instance.
     bit_offset: 1
     bit_size: 1
-  - name: WWDT1
-    description: Watch Dog 0 Fault.
-    bit_offset: 2
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: LFCLKFAIL
     description: LFXT-EXLF Monitor Fail.
     bit_offset: 3

--- a/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
+++ b/data/registers/sysctl_g350x_g310x_g150x_g110x.yaml
@@ -427,10 +427,9 @@ fieldset/HFCLKCLKCFG:
   description: High-frequency clock (HFCLK) configuration.
   fields:
   - name: HFXTTIME
-    description: HFXTTIME specifies the HFXT startup time in 64us resolution. If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time expires.
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
     bit_offset: 0
     bit_size: 8
-    enum: HFXTTIME
   - name: HFXTRSEL
     description: HFXT Range Select.
     bit_offset: 12
@@ -1219,15 +1218,6 @@ enum/HFXTRSEL:
   - name: RANGE32TO48
     description: 32MHz &lt; HFXT frequency &lt;= 48MHz.
     value: 3
-enum/HFXTTIME:
-  bit_size: 8
-  variants:
-  - name: MINSTARTTIME
-    description: Minimum startup time (approximatly zero).
-    value: 0
-  - name: MAXSTARTTIME
-    description: Maximum startup time (approximatly 16.32ms).
-    value: 255
 enum/HSCLKMUX:
   bit_size: 1
   variants:

--- a/data/registers/sysctl_g351x_g151x.yaml
+++ b/data/registers/sysctl_g351x_g151x.yaml
@@ -539,10 +539,9 @@ fieldset/HFCLKCLKCFG:
   description: High-frequency clock (HFCLK) configuration.
   fields:
   - name: HFXTTIME
-    description: HFXTTIME specifies the HFXT startup time in 64us resolution. If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time expires.
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
     bit_offset: 0
     bit_size: 8
-    enum: HFXTTIME
   - name: HFXTRSEL
     description: HFXT Range Select.
     bit_offset: 12
@@ -1333,15 +1332,6 @@ enum/HFXTRSEL:
   - name: RANGE32TO48
     description: 32MHz < HFXT frequency <= 48MHz.
     value: 3
-enum/HFXTTIME:
-  bit_size: 8
-  variants:
-  - name: MINSTARTTIME
-    description: Minimum startup time (approximatly zero).
-    value: 0
-  - name: MAXSTARTTIME
-    description: Maximum startup time (approximatly 16.32ms).
-    value: 255
 enum/HSCLKMUX:
   bit_size: 1
   variants:

--- a/data/registers/sysctl_g351x_g151x.yaml
+++ b/data/registers/sysctl_g351x_g151x.yaml
@@ -225,19 +225,19 @@ block/SYSCTL:
   - name: FRXPROTMAINSTART
     description: Flash RX Protection Start Address.
     byte_offset: 12312
-    fieldset: FRXPROTMAINSTART
+    fieldset: FPROTADDR
   - name: FRXPROTMAINEND
     description: Flash RX Protection End Address.
     byte_offset: 12316
-    fieldset: FRXPROTMAINEND
+    fieldset: FPROTADDR
   - name: FIPPROTMAINSTART
     description: Flash IP Protection Start Address.
     byte_offset: 12320
-    fieldset: FIPPROTMAINSTART
+    fieldset: FPROTADDR
   - name: FIPPROTMAINEND
     description: Flash IP Protection End Address.
     byte_offset: 12324
-    fieldset: FIPPROTMAINEND
+    fieldset: FPROTADDR
   - name: FLBANKSWPPOLICY
     description: Flash Bank Swap Policy.
     byte_offset: 12344
@@ -404,18 +404,11 @@ fieldset/FCCCMD:
     bit_offset: 24
     bit_size: 8
     enum: FCCCMD_KEY
-fieldset/FIPPROTMAINEND:
-  description: Flash IP Protection End Address.
+fieldset/FPROTADDR:
+  description: A flash protection boundary address.
   fields:
   - name: ADDR
-    description: Flash IP Protection End Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
-fieldset/FIPPROTMAINSTART:
-  description: Flash IP Protection Start Address.
-  fields:
-  - name: ADDR
-    description: Flash IP Protection Start Address 64B granularity.
+    description: The boundary address, at 64 byte granularity.
     bit_offset: 6
     bit_size: 16
 fieldset/FLBANKSWP:
@@ -432,20 +425,6 @@ fieldset/FLBANKSWPPOLICY:
     description: '1: Disables Policy To Allow Flash Bank Swapping.'
     bit_offset: 0
     bit_size: 1
-fieldset/FRXPROTMAINEND:
-  description: Flash RX Protection End Address.
-  fields:
-  - name: ADDR
-    description: Flash RX Protection End Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
-fieldset/FRXPROTMAINSTART:
-  description: Flash RX Protection Start Address.
-  fields:
-  - name: ADDR
-    description: Flash RX Protection Start Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
 fieldset/FWENABLE:
   description: Security Firewall Enable Register.
   fields:
@@ -695,14 +674,13 @@ fieldset/NMI:
     description: Clr the BORLVL NMI.
     bit_offset: 0
     bit_size: 1
-  - name: WWDT0
-    description: Watch Dog 0 Fault.
+  - name: WWDT
+    description: Watch dog fault, one bit per WWDT instance.
     bit_offset: 1
     bit_size: 1
-  - name: WWDT1
-    description: Watch Dog 0 Fault.
-    bit_offset: 2
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: LFCLKFAIL
     description: LFXT-EXLF Monitor Fail.
     bit_offset: 3

--- a/data/registers/sysctl_g518x.yaml
+++ b/data/registers/sysctl_g518x.yaml
@@ -1,0 +1,1809 @@
+block/SYSCTL:
+  description: mem_map.
+  items:
+  - name: IIDX
+    description: SYSCTL interrupt index.
+    byte_offset: 4128
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: SYSCTL interrupt mask.
+    byte_offset: 4136
+    fieldset: INT
+  - name: RIS
+    description: SYSCTL raw interrupt status.
+    byte_offset: 4144
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: SYSCTL masked interrupt status.
+    byte_offset: 4152
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: SYSCTL interrupt set.
+    byte_offset: 4160
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: SYSCTL interrupt clear.
+    byte_offset: 4168
+    access: Write
+    fieldset: INT
+  - name: NMIIIDX
+    description: NMI interrupt index.
+    byte_offset: 4176
+    access: Read
+    fieldset: NMIIIDX
+  - name: NMIRIS
+    description: NMI raw interrupt status.
+    byte_offset: 4192
+    access: Read
+    fieldset: NMI
+  - name: NMIISET
+    description: NMI interrupt set.
+    byte_offset: 4208
+    access: Write
+    fieldset: NMI
+  - name: NMIICLR
+    description: NMI interrupt clear.
+    byte_offset: 4216
+    access: Write
+    fieldset: NMI
+  - name: SYSOSCCFG
+    description: SYSOSC configuration.
+    byte_offset: 4352
+    fieldset: SYSOSCCFG
+  - name: MCLKCFG
+    description: Main clock (MCLK) configuration.
+    byte_offset: 4356
+    fieldset: MCLKCFG
+  - name: HSCLKEN
+    description: High-speed clock (HSCLK) source enable/disable.
+    byte_offset: 4360
+    fieldset: HSCLKEN
+  - name: HSCLKCFG
+    description: High-speed clock (HSCLK) source selection.
+    byte_offset: 4364
+    fieldset: HSCLKCFG
+  - name: HFCLKCLKCFG
+    description: High-frequency clock (HFCLK) configuration.
+    byte_offset: 4368
+    fieldset: HFCLKCLKCFG
+  - name: LFCLKCFG
+    description: Low frequency crystal oscillator (LFXT) configuration.
+    byte_offset: 4372
+    fieldset: LFCLKCFG
+  - name: SYSPLLCFG0
+    description: SYSPLL reference and output configuration.
+    byte_offset: 4384
+    fieldset: SYSPLLCFG0
+  - name: SYSPLLCFG1
+    description: SYSPLL reference and feedback divider.
+    byte_offset: 4388
+    fieldset: SYSPLLCFG1
+  - name: SYSPLLPARAM0
+    description: SYSPLL PARAM0 (load from FACTORY region).
+    byte_offset: 4392
+    fieldset: SYSPLLPARAM0
+  - name: SYSPLLPARAM1
+    description: SYSPLL PARAM1 (load from FACTORY region).
+    byte_offset: 4396
+    fieldset: SYSPLLPARAM1
+  - name: GENCLKCFG
+    description: General clock configuration.
+    byte_offset: 4408
+    fieldset: GENCLKCFG
+  - name: GENCLKEN
+    description: General clock enable control.
+    byte_offset: 4412
+    fieldset: GENCLKEN
+  - name: PMODECFG
+    description: Power mode configuration.
+    byte_offset: 4416
+    fieldset: PMODECFG
+  - name: FCC
+    description: Frequency clock counter (FCC) count.
+    byte_offset: 4432
+    access: Read
+    fieldset: FCC
+  - name: SYSOSCTRIMUSER
+    description: SYSOSC user-specified trim.
+    byte_offset: 4464
+    fieldset: SYSOSCTRIMUSER
+  - name: SRAMBOUNDARY
+    description: SRAM Write Boundary.
+    byte_offset: 4472
+    fieldset: SRAMBOUNDARY
+  - name: SYSTEMCFG
+    description: System configuration.
+    byte_offset: 4480
+    fieldset: SYSTEMCFG
+  - name: WRITELOCK
+    description: SYSCTL register write lockout.
+    byte_offset: 4608
+    fieldset: WRITELOCK
+  - name: CLKSTATUS
+    description: Clock module (CKM) status.
+    byte_offset: 4612
+    access: Read
+    fieldset: CLKSTATUS
+  - name: SYSSTATUS
+    description: System status information.
+    byte_offset: 4616
+    access: Read
+    fieldset: SYSSTATUS
+  - name: DEDERRADDR
+    description: Memory DED Address.
+    byte_offset: 4620
+    access: Read
+  - name: RSTCAUSE
+    description: Reset cause.
+    byte_offset: 4640
+    access: Read
+    fieldset: RSTCAUSE
+  - name: RESETLEVEL
+    description: Reset level for application-triggered reset command.
+    byte_offset: 4864
+    fieldset: RESETLEVEL
+  - name: RESETCMD
+    description: Execute an application-triggered reset command.
+    byte_offset: 4868
+    access: Write
+    fieldset: RESETCMD
+  - name: BORTHRESHOLD
+    description: BOR threshold selection.
+    byte_offset: 4872
+    fieldset: BORTHRESHOLD
+  - name: BORCLRCMD
+    description: Set the BOR threshold.
+    byte_offset: 4876
+    access: Write
+    fieldset: BORCLRCMD
+  - name: SYSOSCFCLCTL
+    description: SYSOSC frequency correction loop (FCL) ROSC enable.
+    byte_offset: 4880
+    access: Write
+    fieldset: SYSOSCFCLCTL
+  - name: LFXTCTL
+    description: LFXT and LFCLK control.
+    byte_offset: 4884
+    access: Write
+    fieldset: LFXTCTL
+  - name: EXLFCTL
+    description: LFCLK_IN and LFCLK control.
+    byte_offset: 4888
+    access: Write
+    fieldset: EXLFCTL
+  - name: SHDNIOREL
+    description: SHUTDOWN IO release control.
+    byte_offset: 4892
+    access: Write
+    fieldset: SHDNIOREL
+  - name: EXRSTPIN
+    description: Disable the reset function of the NRST pin.
+    byte_offset: 4896
+    access: Write
+    fieldset: EXRSTPIN
+  - name: SYSSTATUSCLR
+    description: Clear sticky bits of SYSSTATUS.
+    byte_offset: 4900
+    access: Write
+    fieldset: SYSSTATUSCLR
+  - name: SWDCFG
+    description: Disable the SWD function on the SWD pins.
+    byte_offset: 4904
+    access: Write
+    fieldset: SWDCFG
+  - name: FCCCMD
+    description: Frequency clock counter start capture.
+    byte_offset: 4908
+    access: Write
+    fieldset: FCCCMD
+  - name: USBFLLCTL
+    description: USB FLL control.
+    byte_offset: 4928
+    fieldset: USBFLLCTL
+  - name: USBFLLADJ
+    description: USB FLL manual adjustment.
+    byte_offset: 4932
+    fieldset: USBFLLADJ
+  - name: USBFLLSTAT
+    description: USB FLL status.
+    byte_offset: 4936
+    access: Read
+    fieldset: USBFLLSTAT
+  - name: SHUTDNSTORE
+    description: Shutdown storage memory (byte 0).
+    array:
+      len: 4
+      stride: 4
+    byte_offset: 5120
+    fieldset: SHUTDNSTORE
+  - name: FWEPROTMAIN
+    description: 1 Sector Write-Erase per bit starting at address 0x0 of flash.
+    byte_offset: 12288
+  - name: FWPROTMAINDATA
+    description: Read-Write Protection for first 4 Sectors of Data Bank.
+    byte_offset: 12308
+    fieldset: FWPROTMAINDATA
+  - name: FRXPROTMAINSTART
+    description: Flash RX Protection Start Address.
+    byte_offset: 12312
+    fieldset: FPROTADDR
+  - name: FRXPROTMAINEND
+    description: Flash RX Protection End Address.
+    byte_offset: 12316
+    fieldset: FPROTADDR
+  - name: FIPPROTMAINSTART
+    description: Flash IP Protection Start Address.
+    byte_offset: 12320
+    fieldset: FPROTADDR
+  - name: FIPPROTMAINEND
+    description: Flash IP Protection End Address.
+    byte_offset: 12324
+    fieldset: FPROTADDR
+  - name: FLBANKSWPPOLICY
+    description: Flash Bank Swap Policy.
+    byte_offset: 12344
+    access: Write
+    fieldset: FLBANKSWPPOLICY
+  - name: FLBANKSWP
+    description: Flash MAIN bank address swap.
+    byte_offset: 12348
+    access: Write
+    fieldset: FLBANKSWP
+  - name: FWENABLE
+    description: Security Firewall Enable Register.
+    byte_offset: 12356
+    access: Write
+    fieldset: FWENABLE
+  - name: SECSTATUS
+    description: Security Configuration status.
+    byte_offset: 12360
+    access: Read
+    fieldset: SECSTATUS
+  - name: INITDONE
+    description: INITCODE PASS.
+    byte_offset: 12384
+    access: Write
+    fieldset: INITDONE
+fieldset/BORCLRCMD:
+  description: Set the BOR threshold.
+  fields:
+  - name: GO
+    description: GO clears any prior BOR violation status indications and attempts to change the active BOR mode to that specified in the LEVEL field of the BORTHRESHOLD register.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: BORCLRCMD_KEY
+fieldset/BORTHRESHOLD:
+  description: BOR threshold selection.
+  fields:
+  - name: LEVEL
+    description: LEVEL specifies the desired BOR threshold and BOR mode.
+    bit_offset: 0
+    bit_size: 2
+fieldset/CLKSTATUS:
+  description: Clock module (CKM) status.
+  fields:
+  - name: SYSOSCFREQ
+    description: SYSOSCFREQ indicates the current SYSOSC operating frequency.
+    bit_offset: 0
+    bit_size: 2
+    enum: SYSOSCFREQ
+  - name: HSCLKMUX
+    description: HSCLKMUX indicates if MCLK is currently sourced from the high-speed clock (HSCLK).
+    bit_offset: 4
+    bit_size: 1
+    enum: HSCLKMUX
+  - name: LFCLKMUX
+    description: LFCLKMUX indicates if LFCLK is sourced from the internal LFOSC, the low frequency crystal (LFXT), or the LFCLK_IN digital clock input.
+    bit_offset: 6
+    bit_size: 2
+    enum: LFCLKMUX
+  - name: HFCLKGOOD
+    description: HFCLKGOOD indicates that the HFCLK started correctly. When the HFXT is started or HFCLK_IN is selected as the HFCLK source, this bit will be set by hardware if a valid HFCLK is detected, and cleared if HFCLK is not operating within the expected range.
+    bit_offset: 8
+    bit_size: 1
+  - name: SYSPLLGOOD
+    description: SYSPLLGOOD indicates if the SYSPLL started correctly. When the SYSPLL is started, SYSPLLGOOD is cleared by hardware. After the startup settling time has expired, the SYSPLL status is tested. If the SYSPLL started successfully the SYSPLLGOOD bit is set, else it is left cleared.
+    bit_offset: 9
+    bit_size: 1
+  - name: LFXTGOOD
+    description: LFXTGOOD indicates if the LFXT started correctly. When the LFXT is started, LFXTGOOD is cleared by hardware. After the startup settling time has expired, the LFXT status is tested. If the LFXT started successfully the LFXTGOOD bit is set, else it is left cleared.
+    bit_offset: 10
+    bit_size: 1
+  - name: LFOSCGOOD
+    description: LFOSCGOOD indicates when the LFOSC startup has completed and the LFOSC is ready for use.
+    bit_offset: 11
+    bit_size: 1
+  - name: HSCLKSOFF
+    description: HSCLKSOFF is set when the high speed clock sources (SYSPLL, HFCLK) are disabled or dead. It is the logical AND of HFCLKOFF and SYSPLLOFF.
+    bit_offset: 12
+    bit_size: 1
+  - name: HFCLKOFF
+    description: HFCLKOFF indicates if the HFCLK is disabled or was dead at startup. When the HFCLK is started, HFCLKOFF is cleared by hardware. Following startup of the HFCLK, if the HFCLK startup monitor determines that the HFCLK was not started correctly, HFCLKOFF is set.
+    bit_offset: 13
+    bit_size: 1
+  - name: SYSPLLOFF
+    description: SYSPLLOFF indicates if the SYSPLL is disabled or was dead at startup. When the SYSPLL is started, SYSPLLOFF is cleared by hardware. Following startup of the SYSPLL, if the SYSPLL startup monitor determines that the SYSPLL was not started correctly, SYSPLLOFF is set.
+    bit_offset: 14
+    bit_size: 1
+  - name: CURHSCLKSEL
+    description: CURHSCLKSEL indicates the current clock source for HSCLK.
+    bit_offset: 16
+    bit_size: 1
+    enum: CURHSCLKSEL
+  - name: CURMCLKSEL
+    description: CURMCLKSEL indicates if MCLK is currently sourced from LFCLK.
+    bit_offset: 17
+    bit_size: 1
+  - name: HSCLKDEAD
+    description: HSCLKDEAD is set by hardware if the selected source for HSCLK was started but did not start successfully.
+    bit_offset: 20
+    bit_size: 1
+  - name: HSCLKGOOD
+    description: HSCLKGOOD is set by hardware if the selected clock source for HSCLK started successfully.
+    bit_offset: 21
+    bit_size: 1
+  - name: LFCLKFAIL
+    description: LFCLKFAIL indicates when the continous LFCLK monitor detects a LFXT or LFCLK_IN clock stuck failure.
+    bit_offset: 23
+    bit_size: 1
+  - name: FCLMODE
+    description: FCLMODE indicates if the SYSOSC frequency correction loop (FCL) is enabled.
+    bit_offset: 24
+    bit_size: 1
+  - name: FCCDONE
+    description: FCCDONE indicates when a frequency clock counter capture is complete.
+    bit_offset: 25
+    bit_size: 1
+  - name: HFCLKBLKUPD
+    description: HFCLKBLKUPD indicates when writes to the HFCLKCLKCFG register are blocked.
+    bit_offset: 28
+    bit_size: 1
+  - name: SYSPLLBLKUPD
+    description: SYSPLLBLKUPD indicates when writes to SYSPLLCFG0/1 and SYSPLLPARAM0/1 are blocked.
+    bit_offset: 29
+    bit_size: 1
+  - name: ANACLKERR
+    description: ANACLKERR is set when the device clock configuration does not support an enabled analog peripheral mode and the analog peripheral may not be functioning as expected.
+    bit_offset: 31
+    bit_size: 1
+fieldset/EXLFCTL:
+  description: LFCLK_IN and LFCLK control.
+  fields:
+  - name: SETUSEEXLF
+    description: Set SETUSEEXLF to switch LFCLK to the LFCLK_IN digital clock input. Once set, SETUSEEXLF remains set until the next BOOTRST.
+    bit_offset: 0
+    bit_size: 1
+fieldset/EXRSTPIN:
+  description: Disable the reset function of the NRST pin.
+  fields:
+  - name: DISABLE
+    description: Set DISABLE to disable the reset function of the NRST pin. Once set, this configuration is locked until the next POR.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: EXRSTPIN_KEY
+fieldset/FCC:
+  description: Frequency clock counter (FCC) count.
+  fields:
+  - name: DATA
+    description: Frequency clock counter (FCC) count value.
+    bit_offset: 0
+    bit_size: 22
+fieldset/FCCCMD:
+  description: Frequency clock counter start capture.
+  fields:
+  - name: GO
+    description: Set GO to start a capture with the frequency clock counter (FCC).
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: FCCCMD_KEY
+fieldset/FPROTADDR:
+  description: A flash protection boundary address.
+  fields:
+  - name: ADDR
+    description: The boundary address, at 64 byte granularity.
+    bit_offset: 6
+    bit_size: 16
+fieldset/FLBANKSWP:
+  description: Flash MAIN bank address swap.
+  fields:
+  - name: USEUPPER
+    description: '1: Use Upper Bank as Logical 0.'
+    bit_offset: 0
+    bit_size: 1
+fieldset/FLBANKSWPPOLICY:
+  description: Flash Bank Swap Policy.
+  fields:
+  - name: DISABLE
+    description: '1: Disables Policy To Allow Flash Bank Swapping.'
+    bit_offset: 0
+    bit_size: 1
+fieldset/FWENABLE:
+  description: Security Firewall Enable Register.
+  fields:
+  - name: FLRXPROT
+    description: '1: Flash Read Execute Protection Active.'
+    bit_offset: 4
+    bit_size: 1
+  - name: FLIPPROT
+    description: '1: Flash Read IP ProtectionActive.'
+    bit_offset: 6
+    bit_size: 1
+  - name: SRAMBOUNDARYLOCK
+    description: '1: Blocks Writes from Changing SRAMBOUNDARY MMR.'
+    bit_offset: 8
+    bit_size: 1
+fieldset/FWPROTMAINDATA:
+  description: Read-Write Protection for first 4 Sectors of Data Bank.
+  fields:
+  - name: DATA
+    description: '00: Both RW allowed 01: Read Only 10: No Read No Write 11: No Read No Write - Not Used.'
+    bit_offset: 0
+    bit_size: 8
+fieldset/GENCLKCFG:
+  description: General clock configuration.
+  fields:
+  - name: EXCLKSRC
+    description: EXCLKSRC selects the source for the CLK_OUT external clock output block. ULPCLK and MFPCLK require the CLK_OUT divider (EXCLKDIVEN) to be enabled.
+    bit_offset: 0
+    bit_size: 3
+    enum: EXCLKSRC
+  - name: EXCLKDIVVAL
+    description: EXCLKDIVVAL selects the divider value for the divider in the CLK_OUT external clock output block.
+    bit_offset: 4
+    bit_size: 3
+    enum: EXCLKDIVVAL
+  - name: EXCLKDIVEN
+    description: EXCLKDIVEN enables or disables the divider function of the CLK_OUT external clock output block.
+    bit_offset: 7
+    bit_size: 1
+  - name: USBCLKSRC
+    description: USBCLKSRC selects the USBCLK source.
+    bit_offset: 10
+    bit_size: 1
+    enum: USBCLKSRC
+  - name: MFPCLKSRC
+    description: MFPCLKSRC selects the MFPCLK (middle frequency precision clock) source.
+    bit_offset: 9
+    bit_size: 1
+    enum: MFPCLKSRC
+  - name: HFCLK4MFPCLKDIV
+    description: HFCLK4MFPCLKDIV selects the divider applied to HFCLK when HFCLK is used as the MFPCLK source. Integer dividers from /1 to /16 may be selected.
+    bit_offset: 12
+    bit_size: 4
+    enum: HFCLK4MFPCLKDIV
+  - name: FCCSELCLK
+    description: FCCSELCLK selectes the frequency clock counter (FCC) clock source.
+    bit_offset: 16
+    bit_size: 4
+    enum: FCCSELCLK
+  - name: FCCTRIGSRC
+    description: FCCTRIGSRC selects the frequency clock counter (FCC) trigger source.
+    bit_offset: 20
+    bit_size: 1
+    enum: FCCTRIGSRC
+  - name: FCCLVLTRIG
+    description: FCCLVLTRIG selects the frequency clock counter (FCC) trigger mode.
+    bit_offset: 21
+    bit_size: 1
+    enum: FCCLVLTRIG
+  - name: ANACPUMPCFG
+    description: ANACPUMPCFG selects the analog mux charge pump (VBOOST) enable method.
+    bit_offset: 22
+    bit_size: 2
+    enum: ANACPUMPCFG
+  - name: FCCTRIGCNT
+    description: FCCTRIGCNT specifies the number of trigger clock periods in the trigger window. FCCTRIGCNT=0h (one trigger clock period) up to 1Fh (32 trigger clock periods) may be specified.
+    bit_offset: 24
+    bit_size: 5
+  - name: FCCLFCLKSRC
+    description: FCCLFCLKSRC selects between the system LFCLK and an externally sourced LFCLK.
+    bit_offset: 29
+    bit_size: 1
+fieldset/GENCLKEN:
+  description: General clock enable control.
+  fields:
+  - name: EXCLKEN
+    description: EXCLKEN enables the CLK_OUT external clock output block.
+    bit_offset: 0
+    bit_size: 1
+  - name: MFPCLKEN
+    description: MFPCLKEN enables the middle frequency precision clock (MFPCLK).
+    bit_offset: 4
+    bit_size: 1
+fieldset/HFCLKCLKCFG:
+  description: High-frequency clock (HFCLK) configuration.
+  fields:
+  - name: HFXTTIME
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
+    bit_offset: 0
+    bit_size: 8
+  - name: HFXTRSEL
+    description: HFXT Range Select.
+    bit_offset: 12
+    bit_size: 2
+    enum: HFXTRSEL
+  - name: HFCLKFLTCHK
+    description: HFCLKFLTCHK enables or disables the HFCLK startup monitor.
+    bit_offset: 28
+    bit_size: 1
+fieldset/HSCLKCFG:
+  description: High-speed clock (HSCLK) source selection.
+  fields:
+  - name: HSCLKSEL
+    description: HSCLKSEL selects the HSCLK source (SYSPLL or HFCLK).
+    bit_offset: 0
+    bit_size: 1
+    enum: HSCLKSEL
+  - name: USBFLL4HSCLK
+    description: USBFLL4HSCLK selects the USBFLL as the HSCLK source, overriding HSCLKSEL.
+    bit_offset: 1
+    bit_size: 1
+    enum: USBFLL4HSCLK
+fieldset/HSCLKEN:
+  description: High-speed clock (HSCLK) source enable/disable.
+  fields:
+  - name: HFXTEN
+    description: HFXTEN enables or disables the high frequency crystal oscillator (HFXT).
+    bit_offset: 0
+    bit_size: 1
+  - name: SYSPLLEN
+    description: SYSPLLEN enables or disables the system phase-lock loop (SYSPLL).
+    bit_offset: 8
+    bit_size: 1
+  - name: USEEXTHFCLK
+    description: USEEXTHFCLK selects the HFCLK_IN digital clock input to be the source for HFCLK. When disabled, HFXT is the HFCLK source and HFXTEN may be set. Do not set HFXTEN and USEEXTHFCLK simultaneously.
+    bit_offset: 16
+    bit_size: 1
+fieldset/IIDX:
+  description: SYSCTL interrupt index.
+  fields:
+  - name: STAT
+    description: The SYSCTL interrupt index (IIDX) register generates a value corresponding to the highest priority pending interrupt source. This value may be used as an address offset for fast, deterministic handling in the interrupt service routine. A read of the IIDX register will clear the corresponding interrupt status in the RIS and MIS registers.
+    bit_offset: 0
+    bit_size: 4
+    enum: IIDX_STAT
+fieldset/INITDONE:
+  description: INITCODE PASS.
+  fields:
+  - name: PASS
+    description: INITCODE writes 1 for PASS, left unwritten a timeout will occur if not blocked.
+    bit_offset: 0
+    bit_size: 1
+fieldset/INT:
+  description: SYSCTL interrupt clear.
+  fields:
+  - name: LFOSCGOOD
+    description: Clear the LFOSCGOOD interrupt.
+    bit_offset: 0
+    bit_size: 1
+  - name: ANACLKERR
+    description: Analog Clocking Consistency Error.
+    bit_offset: 1
+    bit_size: 1
+  - name: FLASHSEC
+    description: Flash Single Error Correct.
+    bit_offset: 2
+    bit_size: 1
+  - name: SRAMSEC
+    description: SRAM Single Error Correct.
+    bit_offset: 3
+    bit_size: 1
+  - name: LFXTGOOD
+    description: LFXT GOOD.
+    bit_offset: 4
+    bit_size: 1
+  - name: HFCLKGOOD
+    description: HFCLK GOOD.
+    bit_offset: 5
+    bit_size: 1
+  - name: SYSPLLGOOD
+    description: SYSPLL GOOD.
+    bit_offset: 6
+    bit_size: 1
+  - name: HSCLKGOOD
+    description: HSCLK GOOD.
+    bit_offset: 7
+    bit_size: 1
+  - name: USBFLLERR
+    description: USB FLL error.
+    bit_offset: 8
+    bit_size: 1
+fieldset/LFCLKCFG:
+  description: Low frequency crystal oscillator (LFXT) configuration.
+  fields:
+  - name: XT1DRIVE
+    description: XT1DRIVE selects the low frequency crystal oscillator (LFXT) drive strength.
+    bit_offset: 0
+    bit_size: 2
+    enum: XT1DRIVE
+  - name: MONITOR
+    description: MONITOR enables or disables the LFCLK monitor, which continuously checks LFXT or LFCLK_IN for a clock stuck fault.
+    bit_offset: 4
+    bit_size: 1
+  - name: LOWCAP
+    description: LOWCAP controls the low-power LFXT mode. When the LFXT load capacitance is less than 3pf, LOWCAP may be set for reduced power consumption.
+    bit_offset: 8
+    bit_size: 1
+fieldset/LFXTCTL:
+  description: LFXT and LFCLK control.
+  fields:
+  - name: STARTLFXT
+    description: Set STARTLFXT to start the low frequency crystal oscillator (LFXT). Once set, STARTLFXT remains set until the next BOOTRST.
+    bit_offset: 0
+    bit_size: 1
+  - name: SETUSELFXT
+    description: Set SETUSELFXT to switch LFCLK to LFXT. Once set, SETUSELFXT remains set until the next BOOTRST.
+    bit_offset: 1
+    bit_size: 1
+fieldset/MCLKCFG:
+  description: Main clock (MCLK) configuration.
+  fields:
+  - name: MDIV
+    description: MDIV may be used to divide the MCLK frequency when MCLK is sourced from SYSOSC. MDIV=0h corresponds to /1 (no divider). MDIV=1h corresponds to /2 (divide-by-2). MDIV=Fh corresponds to /16 (divide-by-16). MDIV may be set between /1 and /16 on an integer basis.
+    bit_offset: 0
+    bit_size: 4
+  - name: UDIV
+    description: UDIV specifies the ULPCLK divider when MCLK is sourced from HSCLK. UDIV has no effect when MCLK is sourced from SYSOSC or LFCLK.
+    bit_offset: 4
+    bit_size: 2
+    enum: UDIV
+  - name: FLASHWAIT
+    description: FLASHWAIT specifies the number of flash wait states when MCLK is sourced from HSCLK. FLASHWAIT has no effect when MCLK is sourced from SYSOSC or LFCLK.
+    bit_offset: 8
+    bit_size: 4
+    enum: FLASHWAIT
+  - name: USEMFTICK
+    description: USEMFTICK specifies whether the 4MHz constant-rate clock (MFCLK) to peripherals is enabled or disabled. When enabled, MDIV must be disabled (set to 0h=/1).
+    bit_offset: 12
+    bit_size: 1
+  - name: USEHSCLK
+    description: USEHSCLK, together with USELFCLK, sets the MCLK source policy. Set USEHSCLK to use HSCLK (HFCLK or SYSPLL) as the MCLK source in RUN and SLEEP modes.
+    bit_offset: 16
+    bit_size: 1
+  - name: USELFCLK
+    description: USELFCLK sets the MCLK source policy. Set USELFCLK to use LFCLK as the MCLK source. Note that setting USELFCLK does not disable SYSOSC, and SYSOSC remains available for direct use by analog modules.
+    bit_offset: 20
+    bit_size: 1
+  - name: STOPCLKSTBY
+    description: STOPCLKSTBY sets the STANDBY mode policy (STANDBY0 or STANDBY1). When set, ULPCLK and LFCLK are disabled to all peripherals in STANDBY mode, with the exception of TIMG0 and TIMG1 which continue to run. Wake-up is only possible via an asynchronous fast clock request.
+    bit_offset: 21
+    bit_size: 1
+  - name: MCLKDEADCHK
+    description: MCLKDEADCHK enables or disables the continuous MCLK dead check monitor. LFCLK must be running before MCLKDEADCHK is enabled.
+    bit_offset: 22
+    bit_size: 1
+fieldset/NMI:
+  description: NMI interrupt clear.
+  fields:
+  - name: BORLVL
+    description: Clr the BORLVL NMI.
+    bit_offset: 0
+    bit_size: 1
+  - name: WWDT
+    description: Watch dog fault, one bit per WWDT instance.
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 2
+      stride: 1
+  - name: LFCLKFAIL
+    description: LFXT-EXLF Monitor Fail.
+    bit_offset: 3
+    bit_size: 1
+  - name: FLASHDED
+    description: Flash Double Error Detect.
+    bit_offset: 4
+    bit_size: 1
+  - name: SRAMDED
+    description: SRAM Double Error Detect.
+    bit_offset: 5
+    bit_size: 1
+fieldset/NMIIIDX:
+  description: NMI interrupt index.
+  fields:
+  - name: STAT
+    description: The NMI interrupt index (NMIIIDX) register generates a value corresponding to the highest priority pending NMI source. This value may be used as an address offset for fast, deterministic handling in the NMI service routine. A read of the NMIIIDX register will clear the corresponding interrupt status in the NMIRIS register.
+    bit_offset: 0
+    bit_size: 4
+    enum: NMIIIDX_STAT
+fieldset/PMODECFG:
+  description: Power mode configuration.
+  fields:
+  - name: DSLEEP
+    description: DSLEEP selects the operating mode to enter upon a DEEPSLEEP request from the CPU.
+    bit_offset: 0
+    bit_size: 2
+    enum: DSLEEP
+fieldset/RESETCMD:
+  description: Execute an application-triggered reset command.
+  fields:
+  - name: GO
+    description: Execute the reset specified in RESETLEVEL.LEVEL. Must be written together with the KEY.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: RESETCMD_KEY
+fieldset/RESETLEVEL:
+  description: Reset level for application-triggered reset command.
+  fields:
+  - name: LEVEL
+    description: LEVEL is used to specify the type of reset to be issued when RESETCMD is set to generate a software triggered reset.
+    bit_offset: 0
+    bit_size: 3
+    enum: RESETLEVEL_LEVEL
+fieldset/RSTCAUSE:
+  description: Reset cause.
+  fields:
+  - name: ID
+    description: ID is a read-to-clear field which indicates the lowest level reset cause since the last read.
+    bit_offset: 0
+    bit_size: 5
+    enum: ID
+fieldset/SECSTATUS:
+  description: Security Configuration status.
+  fields:
+  - name: INITDONE
+    description: '1: CSC has been completed.'
+    bit_offset: 0
+    bit_size: 1
+  - name: CSCEXISTS
+    description: '1: CSC Exists in the system.'
+    bit_offset: 2
+    bit_size: 1
+  - name: FLRXPROT
+    description: '1: Flash Read Execute Protection Active.'
+    bit_offset: 4
+    bit_size: 1
+  - name: FLIPPROT
+    description: '1: Flash IP Protection Active.'
+    bit_offset: 6
+    bit_size: 1
+  - name: SRAMBOUNDARYLOCK
+    description: '1: SRAM Boundary MMR Locked.'
+    bit_offset: 8
+    bit_size: 1
+  - name: FLBANKSWPPOLICY
+    description: '1: Upper and Lower Banks allowed to be swapped.'
+    bit_offset: 10
+    bit_size: 1
+  - name: FLBANKSWP
+    description: '1: Upper and Lower Banks have been swapped.'
+    bit_offset: 12
+    bit_size: 1
+fieldset/SHDNIOREL:
+  description: SHUTDOWN IO release control.
+  fields:
+  - name: RELEASE
+    description: Set RELEASE to release the IO after a SHUTDOWN mode exit.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SHDNIOREL_KEY
+fieldset/SHUTDNSTORE:
+  description: Shutdown storage memory (byte 0).
+  fields:
+  - name: DATA
+    description: Shutdown storage byte 0.
+    bit_offset: 0
+    bit_size: 8
+fieldset/SRAMBOUNDARY:
+  description: SRAM Write Boundary.
+  fields:
+  - name: ADDR
+    description: 'SRAM boundary configuration. The value configured into this acts such that: SRAM accesses to addresses less than or equal value will be RW only. SRAM accesses to addresses greater than value will be RX only. Value of 0 is not valid (system will have no stack). If set to 0, the system acts as if the entire SRAM is RWX. Any non-zero value can be configured, including a value = SRAM size.'
+    bit_offset: 5
+    bit_size: 15
+fieldset/SWDCFG:
+  description: Disable the SWD function on the SWD pins.
+  fields:
+  - name: DISABLE
+    description: Set DISABLE to disable the SWD function on SWD pins, allowing the SWD pins to be used as GPIO.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SWDCFG_KEY
+fieldset/SYSOSCCFG:
+  description: SYSOSC configuration.
+  fields:
+  - name: FREQ
+    description: Target operating frequency for the system oscillator (SYSOSC).
+    bit_offset: 0
+    bit_size: 2
+    enum: SYSOSCCFG_FREQ
+  - name: USE4MHZSTOP
+    description: USE4MHZSTOP sets the SYSOSC stop mode frequency policy. When entering STOP mode, the SYSOSC frequency may be automatically switched to 4MHz to reduce SYSOSC power consumption.
+    bit_offset: 8
+    bit_size: 1
+  - name: DISABLESTOP
+    description: DISABLESTOP sets the SYSOSC stop mode enable/disable policy. When operating in STOP mode, the SYSOSC may be automatically disabled. When set, ULPCLK will run from LFCLK in STOP mode and SYSOSC will be disabled to reduce power consumption.
+    bit_offset: 9
+    bit_size: 1
+  - name: DISABLE
+    description: DISABLE sets the SYSOSC enable/disable policy. SYSOSC may be powered off in RUN, SLEEP, and STOP modes to reduce power consumption. When SYSOSC is disabled, MCLK and ULPCLK are sourced from LFCLK.
+    bit_offset: 10
+    bit_size: 1
+  - name: BLOCKASYNCALL
+    description: BLOCKASYNCALL may be used to mask block all asynchronous fast clock requests, preventing hardware from dynamically changing the active clock configuration when operating in a given mode.
+    bit_offset: 16
+    bit_size: 1
+  - name: FASTCPUEVENT
+    description: FASTCPUEVENT may be used to assert a fast clock request when an interrupt is asserted to the CPU, reducing interrupt latency.
+    bit_offset: 17
+    bit_size: 1
+fieldset/SYSOSCFCLCTL:
+  description: SYSOSC frequency correction loop (FCL) ROSC enable.
+  fields:
+  - name: SETUSEFCL
+    description: Set SETUSEFCL to enable the frequency correction loop in SYSOSC. Once enabled, this state is locked until the next BOOTRST.
+    bit_offset: 0
+    bit_size: 1
+  - name: SETUSEEXRES
+    description: Set SETUSEEXRES to specify that an external resistor will be used for the FCL. An appropriate resistor must be populated on the ROSC pin. This state is locked until the next BOOTRST.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SYSOSCFCLCTL_KEY
+fieldset/SYSOSCTRIMUSER:
+  description: SYSOSC user-specified trim.
+  fields:
+  - name: FREQ
+    description: FREQ specifies the target user-trimmed frequency for SYSOSC.
+    bit_offset: 0
+    bit_size: 2
+    enum: SYSOSCTRIMUSER_FREQ
+  - name: CAP
+    description: CAP specifies the SYSOSC capacitor trim. This value changes with the target frequency.
+    bit_offset: 4
+    bit_size: 3
+  - name: RESCOARSE
+    description: RESCOARSE specifies the resister coarse trim. This value changes with the target frequency.
+    bit_offset: 8
+    bit_size: 6
+  - name: RESFINE
+    description: RESFINE specifies the resister fine trim. This value changes with the target frequency.
+    bit_offset: 16
+    bit_size: 4
+  - name: RDIV
+    description: RDIV specifies the frequency correction loop (FCL) resistor trim. This value changes with the target frequency.
+    bit_offset: 20
+    bit_size: 9
+fieldset/SYSPLLCFG0:
+  description: SYSPLL reference and output configuration.
+  fields:
+  - name: SYSPLLREF
+    description: SYSPLLREF selects the system PLL (SYSPLL) reference clock source.
+    bit_offset: 0
+    bit_size: 1
+    enum: SYSPLLREF
+  - name: MCLK2XVCO
+    description: MCLK2XVCO selects the SYSPLL output which is sent to the HSCLK mux for use by MCLK.
+    bit_offset: 1
+    bit_size: 1
+  - name: ENABLECLK0
+    description: ENABLECLK0 enables or disables the SYSPLLCLK0 output.
+    bit_offset: 4
+    bit_size: 1
+  - name: ENABLECLK1
+    description: ENABLECLK1 enables or disables the SYSPLLCLK1 output.
+    bit_offset: 5
+    bit_size: 1
+  - name: ENABLECLK2X
+    description: ENABLECLK2X enables or disables the SYSPLLCLK2X output.
+    bit_offset: 6
+    bit_size: 1
+  - name: RDIVCLK0
+    description: RDIVCLK0 sets the final divider for the SYSPLLCLK0 output.
+    bit_offset: 8
+    bit_size: 4
+    enum: RDIVCLK0
+  - name: RDIVCLK1
+    description: RDIVCLK1 sets the final divider for the SYSPLLCLK1 output.
+    bit_offset: 12
+    bit_size: 4
+    enum: RDIVCLK1
+  - name: RDIVCLK2X
+    description: RDIVCLK2X sets the final divider for the SYSPLLCLK2X output.
+    bit_offset: 16
+    bit_size: 4
+    enum: RDIVCLK2X
+fieldset/SYSPLLCFG1:
+  description: SYSPLL reference and feedback divider.
+  fields:
+  - name: PDIV
+    description: PDIV selects the SYSPLL reference clock prescale divider.
+    bit_offset: 0
+    bit_size: 2
+    enum: PDIV
+  - name: QDIV
+    description: QDIV selects the SYSPLL feedback path divider.
+    bit_offset: 8
+    bit_size: 7
+    enum: QDIV
+fieldset/SYSPLLPARAM0:
+  description: SYSPLL PARAM0 (load from FACTORY region).
+  fields:
+  - name: STARTTIME
+    description: Startup time from enable to locked clock, in 1us resolution.
+    bit_offset: 0
+    bit_size: 6
+  - name: STARTTIMELP
+    description: Startup time from low power mode exit to locked clock, in 1us resolution.
+    bit_offset: 8
+    bit_size: 6
+  - name: CPCURRENT
+    description: Charge pump current.
+    bit_offset: 16
+    bit_size: 6
+  - name: CAPBVAL
+    description: Override value for Cap B.
+    bit_offset: 24
+    bit_size: 5
+  - name: CAPBOVERRIDE
+    description: CAPBOVERRIDE controls the override for Cap B.
+    bit_offset: 31
+    bit_size: 1
+fieldset/SYSPLLPARAM1:
+  description: SYSPLL PARAM1 (load from FACTORY region).
+  fields:
+  - name: LPFCAPA
+    description: Loop filter Cap A.
+    bit_offset: 0
+    bit_size: 5
+  - name: LPFRESA
+    description: Loop filter Res A.
+    bit_offset: 8
+    bit_size: 10
+  - name: LPFRESC
+    description: Loop filter Res C.
+    bit_offset: 24
+    bit_size: 8
+fieldset/SYSSTATUS:
+  description: System status information.
+  fields:
+  - name: FLASHDED
+    description: FLASHDED indicates if a flash ECC double bit error was detected (DED).
+    bit_offset: 0
+    bit_size: 1
+  - name: FLASHSEC
+    description: FLASHSEC indicates if a flash ECC single bit error was detected and corrected (SEC).
+    bit_offset: 1
+    bit_size: 1
+  - name: BORCURTHRESHOLD
+    description: BORCURTHRESHOLD indicates the active brown-out reset supply monitor configuration.
+    bit_offset: 2
+    bit_size: 2
+    enum: BORCURTHRESHOLD
+  - name: BORLVL
+    description: BORLVL indicates if a BOR event occured and the BOR threshold was switched to BOR0 by hardware.
+    bit_offset: 4
+    bit_size: 1
+  - name: ANACPUMPGOOD
+    description: ANACPUMPGOOD is set by hardware when the VBOOST analog mux charge pump is ready.
+    bit_offset: 5
+    bit_size: 1
+  - name: PMUIREFGOOD
+    description: PMUIREFGOOD is set by hardware when the PMU current reference is ready.
+    bit_offset: 6
+    bit_size: 1
+  - name: EXTRSTPINDIS
+    description: EXTRSTPINDIS indicates when user has disabled the use of external reset pin.
+    bit_offset: 12
+    bit_size: 1
+  - name: SWDCFGDIS
+    description: SWDCFGDIS indicates when user has disabled the use of SWD Port.
+    bit_offset: 13
+    bit_size: 1
+  - name: SHDNIOLOCK
+    description: SHDNIOLOCK indicates when IO is locked due to SHUTDOWN.
+    bit_offset: 14
+    bit_size: 1
+  - name: NPUREADY
+    description: NPUREADY indicates when the NPU is ready.
+    bit_offset: 24
+    bit_size: 1
+  - name: USBFS0READY
+    description: USBFS0READY indicates when the USBFS0 peripheral is ready.
+    bit_offset: 25
+    bit_size: 1
+  - name: REBOOTATTEMPTS
+    description: REBOOTATTEMPTS indicates the number of boot attempts taken before the user application starts.
+    bit_offset: 30
+    bit_size: 2
+fieldset/SYSSTATUSCLR:
+  description: Clear sticky bits of SYSSTATUS.
+  fields:
+  - name: ALLECC
+    description: Set ALLECC to clear all ECC related SYSSTATUS indicators.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    bit_offset: 24
+    bit_size: 8
+    enum: SYSSTATUSCLR_KEY
+fieldset/SYSTEMCFG:
+  description: System configuration.
+  fields:
+  - name: WWDTLP0RSTDIS
+    description: WWDTLP0RSTDIS specifies whether a WWDT Error Event will trigger a BOOTRST or an NMI.
+    bit_offset: 0
+    bit_size: 1
+  - name: WWDTLP1RSTDIS
+    description: WWDTLP1RSTDIS specifies whether a WWDT Error Event will trigger a SYSRST or an NMI.
+    bit_offset: 1
+    bit_size: 1
+  - name: FLASHECCRSTDIS
+    description: FLASHECCRSTDIS specifies whether a flash ECC double error detect (DED) will trigger a SYSRST or an NMI.
+    bit_offset: 2
+    bit_size: 1
+fieldset/USBFLLADJ:
+  description: USB FLL manual adjustment.
+  fields:
+  - name: FRQADJ
+    description: Frequency lock loop adjust.
+    bit_offset: 0
+    bit_size: 6
+  - name: FRQMOD
+    description: Frequency lock loop modulator value.
+    bit_offset: 8
+    bit_size: 3
+fieldset/USBFLLCTL:
+  description: USB FLL control.
+  fields:
+  - name: CLKEN
+    description: USB oscillator enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: FLLEN
+    description: USB oscillator frequency lock loop enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: REFSEL
+    description: Reference clock selection for the frequency lock loop.
+    bit_offset: 8
+    bit_size: 1
+    enum: REFSEL
+fieldset/USBFLLSTAT:
+  description: USB FLL status.
+  fields:
+  - name: CLKRDY
+    description: USB oscillator ready indication.
+    bit_offset: 0
+    bit_size: 1
+  - name: FLLLOCK
+    description: USB oscillator frequency lock loop lock indication.
+    bit_offset: 1
+    bit_size: 1
+  - name: REFRDY
+    description: Reference clock for the frequency lock loop ready indication.
+    bit_offset: 8
+    bit_size: 1
+  - name: FRQADJ
+    description: Current frequency lock loop adjust.
+    bit_offset: 16
+    bit_size: 6
+  - name: FRQMOD
+    description: Current frequency lock loop modulator value.
+    bit_offset: 24
+    bit_size: 3
+fieldset/WRITELOCK:
+  description: SYSCTL register write lockout.
+  fields:
+  - name: ACTIVE
+    description: ACTIVE controls whether critical SYSCTL registers are write protected or not.
+    bit_offset: 0
+    bit_size: 1
+enum/ANACPUMPCFG:
+  bit_size: 2
+  variants:
+  - name: ONDEMAND
+    description: VBOOST is enabled on request from a COMP, GPAMP, or OPA.
+    value: 0
+  - name: ONACTIVE
+    description: VBOOST is enabled when the device is in RUN or SLEEP mode, or when a COMP/GPAMP/OPA is enabled.
+    value: 1
+  - name: ONALWAYS
+    description: VBOOST is always enabled.
+    value: 2
+enum/BORCLRCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 199
+enum/BORCURTHRESHOLD:
+  bit_size: 2
+  variants:
+  - name: BORMIN
+    description: Default minimum threshold; a BOR0- violation triggers a BOR.
+    value: 0
+  - name: BORLEVEL1
+    description: A BOR1- violation generates a BORLVL interrupt.
+    value: 1
+  - name: BORLEVEL2
+    description: A BOR2- violation generates a BORLVL interrupt.
+    value: 2
+  - name: BORLEVEL3
+    description: A BOR3- violation generates a BORLVL interrupt.
+    value: 3
+enum/CURHSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: HSCLK is currently sourced from the SYSPLL.
+    value: 0
+  - name: HFCLK
+    description: HSCLK is currently sourced from the HFCLK.
+    value: 1
+enum/DSLEEP:
+  bit_size: 2
+  variants:
+  - name: STOP
+    description: STOP mode is entered.
+    value: 0
+  - name: STANDBY
+    description: STANDBY mode is entered.
+    value: 1
+  - name: SHUTDOWN
+    description: SHUTDOWN mode is entered.
+    value: 2
+enum/EXCLKDIVVAL:
+  bit_size: 3
+  variants:
+  - name: DIV2
+    description: CLK_OUT source is divided by 2.
+    value: 0
+  - name: DIV4
+    description: CLK_OUT source is divided by 4.
+    value: 1
+  - name: DIV6
+    description: CLK_OUT source is divided by 6.
+    value: 2
+  - name: DIV8
+    description: CLK_OUT source is divided by 8.
+    value: 3
+  - name: DIV10
+    description: CLK_OUT source is divided by 10.
+    value: 4
+  - name: DIV12
+    description: CLK_OUT source is divided by 12.
+    value: 5
+  - name: DIV14
+    description: CLK_OUT source is divided by 14.
+    value: 6
+  - name: DIV16
+    description: CLK_OUT source is divided by 16.
+    value: 7
+enum/EXCLKSRC:
+  bit_size: 3
+  variants:
+  - name: SYSOSC
+    description: CLK_OUT is SYSOSC.
+    value: 0
+  - name: ULPCLK
+    description: CLK_OUT is ULPCLK (EXCLKDIVEN must be enabled).
+    value: 1
+  - name: LFCLK
+    description: CLK_OUT is LFCLK.
+    value: 2
+  - name: MFPCLK
+    description: CLK_OUT is MFPCLK (EXCLKDIVEN must be enabled).
+    value: 3
+  - name: HFCLK
+    description: CLK_OUT is HFCLK.
+    value: 4
+  - name: SYSPLLOUT1
+    description: CLK_OUT is SYSPLLCLK1 (SYSPLLCLK1 must be <=48MHz).
+    value: 5
+  - name: USBFLL
+    description: CLK_OUT is USBFLL (at 60MHz it must be divided for external output).
+    value: 6
+enum/EXRSTPIN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 30
+enum/FCCCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 14
+enum/FCCLVLTRIG:
+  bit_size: 1
+  variants:
+  - name: RISE2RISE
+    description: Rising edge to rising edge triggered.
+    value: 0
+  - name: LEVEL
+    description: Level triggered.
+    value: 1
+enum/FCCSELCLK:
+  bit_size: 4
+  variants:
+  - name: MCLK
+    description: FCC clock is MCLK.
+    value: 0
+  - name: SYSOSC
+    description: FCC clock is SYSOSC.
+    value: 1
+  - name: HFCLK
+    description: FCC clock is HFCLK.
+    value: 2
+  - name: EXTCLK
+    description: FCC clock is the CLK_OUT selection.
+    value: 3
+  - name: SYSPLLCLK0
+    description: FCC clock is SYSPLLCLK0.
+    value: 4
+  - name: SYSPLLCLK1
+    description: FCC clock is SYSPLLCLK1.
+    value: 5
+  - name: SYSPLLCLK2X
+    description: FCC clock is SYSPLLCLK2X.
+    value: 6
+  - name: FCCIN
+    description: FCC clock is the FCCIN external input.
+    value: 7
+enum/FCCTRIGSRC:
+  bit_size: 1
+  variants:
+  - name: EXTPIN
+    description: FCC trigger is the external pin.
+    value: 0
+  - name: LFCLK
+    description: FCC trigger is the LFCLK.
+    value: 1
+enum/FLASHWAIT:
+  bit_size: 4
+  variants:
+  - name: WAIT0
+    description: No flash wait states are applied.
+    value: 0
+  - name: WAIT1
+    description: One flash wait state is applied.
+    value: 1
+  - name: WAIT2
+    description: 2 flash wait states are applied.
+    value: 2
+enum/HFCLK4MFPCLKDIV:
+  bit_size: 4
+  variants:
+  - name: DIV1
+    description: HFCLK is not divided before being used for MFPCLK.
+    value: 0
+  - name: DIV2
+    description: HFCLK is divided by 2 before being used for MFPCLK.
+    value: 1
+  - name: DIV3
+    description: HFCLK is divided by 3 before being used for MFPCLK.
+    value: 2
+  - name: DIV4
+    description: HFCLK is divided by 4 before being used for MFPCLK.
+    value: 3
+  - name: DIV5
+    description: HFCLK is divided by 5 before being used for MFPCLK.
+    value: 4
+  - name: DIV6
+    description: HFCLK is divided by 6 before being used for MFPCLK.
+    value: 5
+  - name: DIV7
+    description: HFCLK is divided by 7 before being used for MFPCLK.
+    value: 6
+  - name: DIV8
+    description: HFCLK is divided by 8 before being used for MFPCLK.
+    value: 7
+  - name: DIV9
+    description: HFCLK is divided by 9 before being used for MFPCLK.
+    value: 8
+  - name: DIV10
+    description: HFCLK is divided by 10 before being used for MFPCLK.
+    value: 9
+  - name: DIV11
+    description: HFCLK is divided by 11 before being used for MFPCLK.
+    value: 10
+  - name: DIV12
+    description: HFCLK is divided by 12 before being used for MFPCLK.
+    value: 11
+  - name: DIV13
+    description: HFCLK is divided by 13 before being used for MFPCLK.
+    value: 12
+  - name: DIV14
+    description: HFCLK is divided by 14 before being used for MFPCLK.
+    value: 13
+  - name: DIV15
+    description: HFCLK is divided by 15 before being used for MFPCLK.
+    value: 14
+  - name: DIV16
+    description: HFCLK is divided by 16 before being used for MFPCLK.
+    value: 15
+enum/HFXTRSEL:
+  bit_size: 2
+  variants:
+  - name: RANGE4TO8
+    description: 4MHz <= HFXT frequency <= 8MHz.
+    value: 0
+  - name: RANGE8TO16
+    description: 8MHz < HFXT frequency <= 16MHz.
+    value: 1
+  - name: RANGE16TO32
+    description: 16MHz < HFXT frequency <= 32MHz.
+    value: 2
+  - name: RANGE32TO48
+    description: 32MHz < HFXT frequency <= 48MHz.
+    value: 3
+enum/HSCLKMUX:
+  bit_size: 1
+  variants:
+  - name: SYSOSC
+    description: MCLK is not sourced from HSCLK.
+    value: 0
+  - name: HSCLK
+    description: MCLK is sourced from HSCLK.
+    value: 1
+enum/HSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: HSCLK is sourced from the SYSPLL.
+    value: 0
+  - name: HFCLKCLK
+    description: HSCLK is sourced from the HFCLK.
+    value: 1
+enum/ID:
+  bit_size: 5
+  variants:
+  - name: NORST
+    description: No reset since last read.
+    value: 0
+  - name: PORHWFAIL
+    description: POR- violation, SHUTDNSTOREx or PMU trim parity fault.
+    value: 1
+  - name: POREXNRST
+    description: NRST triggered POR (>1s hold).
+    value: 2
+  - name: PORSW
+    description: Software triggered POR.
+    value: 3
+  - name: BORSUPPLY
+    description: BOR0- violation.
+    value: 4
+  - name: BORWAKESHUTDN
+    description: SHUTDOWN mode exit.
+    value: 5
+  - name: BOOTCLKFAIL
+    description: Fatal clock failure.
+    value: 9
+  - name: BOOTEXNRST
+    description: NRST triggered BOOTRST (<1s hold).
+    value: 12
+  - name: BOOTSW
+    description: Software triggered BOOTRST.
+    value: 13
+  - name: BOOTWWDT0
+    description: WWDT0 violation.
+    value: 14
+  - name: SYSBSLEXIT
+    description: BSL exit.
+    value: 16
+  - name: SYSBSLENTRY
+    description: BSL entry.
+    value: 17
+  - name: SYSWWDT1
+    description: WWDT1 violation.
+    value: 19
+  - name: SYSCPULOCK
+    description: CPULOCK violation.
+    value: 21
+  - name: SYSDBG
+    description: Debug triggered SYSRST.
+    value: 26
+  - name: SYSSW
+    description: Software triggered SYSRST.
+    value: 27
+  - name: CPUDBG
+    description: Debug triggered CPURST.
+    value: 28
+  - name: CPUSW
+    description: Software triggered CPURST.
+    value: 29
+enum/IIDX_STAT:
+  bit_size: 4
+  variants:
+  - name: NO_INTR
+    description: No interrupt pending.
+    value: 0
+  - name: LFOSCGOOD
+    description: LFOSCGOOD interrupt pending.
+    value: 1
+  - name: ANACLKERR
+    value: 2
+  - name: FLASHSEC
+    value: 3
+  - name: SRAMSEC
+    value: 4
+  - name: LFXTGOOD
+    value: 5
+  - name: HFCLKGOOD
+    value: 6
+  - name: SYSPLLGOOD
+    value: 7
+  - name: HSCLKGOOD
+    value: 8
+enum/LFCLKMUX:
+  bit_size: 2
+  variants:
+  - name: LFOSC
+    description: LFCLK is sourced from the internal LFOSC.
+    value: 0
+  - name: LFXT
+    description: LFCLK is sourced from the LFXT (crystal).
+    value: 1
+  - name: EXLF
+    description: LFCLK is sourced from LFCLK_IN (external digital clock input).
+    value: 2
+enum/MFPCLKSRC:
+  bit_size: 1
+  variants:
+  - name: SYSOSC
+    description: MFPCLK is sourced from SYSOSC.
+    value: 0
+  - name: HFCLK
+    description: MFPCLK is sourced from HFCLK.
+    value: 1
+enum/NMIIIDX_STAT:
+  bit_size: 4
+  variants:
+  - name: NO_INTR
+    description: No NMI pending.
+    value: 0
+  - name: BORLVL
+    description: BOR Threshold NMI pending.
+    value: 1
+  - name: WWDT0
+    value: 2
+  - name: WWDT1
+    value: 3
+  - name: LFCLKFAIL
+    value: 4
+  - name: FLASHDED
+    value: 5
+  - name: SRAMDED
+    value: 6
+enum/PDIV:
+  bit_size: 2
+  variants:
+  - name: REFDIV1
+    description: SYSPLLREF is not divided.
+    value: 0
+  - name: REFDIV2
+    description: SYSPLLREF is divided by 2.
+    value: 1
+  - name: REFDIV4
+    description: SYSPLLREF is divided by 4.
+    value: 2
+  - name: REFDIV8
+    description: SYSPLLREF is divided by 8.
+    value: 3
+enum/QDIV:
+  bit_size: 7
+  variants:
+  - name: INVALID
+    description: Divide-by-one is not a valid QDIV option.
+    value: 0
+  - name: QDIVMIN
+    description: Feedback path is divided by 2.
+    value: 1
+  - name: QDIVMAX
+    description: Feedback path is divided by 127 (0x7E).
+    value: 126
+enum/RDIVCLK0:
+  bit_size: 4
+  variants:
+  - name: CLK0DIV2
+    description: SYSPLLCLK0 is divided by 2.
+    value: 0
+  - name: CLK0DIV4
+    description: SYSPLLCLK0 is divided by 4.
+    value: 1
+  - name: CLK0DIV6
+    description: SYSPLLCLK0 is divided by 6.
+    value: 2
+  - name: CLK0DIV8
+    description: SYSPLLCLK0 is divided by 8.
+    value: 3
+  - name: CLK0DIV10
+    description: SYSPLLCLK0 is divided by 10.
+    value: 4
+  - name: CLK0DIV12
+    description: SYSPLLCLK0 is divided by 12.
+    value: 5
+  - name: CLK0DIV14
+    description: SYSPLLCLK0 is divided by 14.
+    value: 6
+  - name: CLK0DIV16
+    description: SYSPLLCLK0 is divided by 16.
+    value: 7
+  - name: CLK0DIV18
+    description: SYSPLLCLK0 is divided by 18.
+    value: 8
+  - name: CLK0DIV20
+    description: SYSPLLCLK0 is divided by 20.
+    value: 9
+  - name: CLK0DIV22
+    description: SYSPLLCLK0 is divided by 22.
+    value: 10
+  - name: CLK0DIV24
+    description: SYSPLLCLK0 is divided by 24.
+    value: 11
+  - name: CLK0DIV26
+    description: SYSPLLCLK0 is divided by 26.
+    value: 12
+  - name: CLK0DIV28
+    description: SYSPLLCLK0 is divided by 28.
+    value: 13
+  - name: CLK0DIV30
+    description: SYSPLLCLK0 is divided by 30.
+    value: 14
+  - name: CLK0DIV32
+    description: SYSPLLCLK0 is divided by 32.
+    value: 15
+enum/RDIVCLK1:
+  bit_size: 4
+  variants:
+  - name: CLK1DIV2
+    description: SYSPLLCLK1 is divided by 2.
+    value: 0
+  - name: CLK1DIV4
+    description: SYSPLLCLK1 is divided by 4.
+    value: 1
+  - name: CLK1DIV6
+    description: SYSPLLCLK1 is divided by 6.
+    value: 2
+  - name: CLK1DIV8
+    description: SYSPLLCLK1 is divided by 8.
+    value: 3
+  - name: CLK1DIV10
+    description: SYSPLLCLK1 is divided by 10.
+    value: 4
+  - name: CLK1DIV12
+    description: SYSPLLCLK1 is divided by 12.
+    value: 5
+  - name: CLK1DIV14
+    description: SYSPLLCLK1 is divided by 14.
+    value: 6
+  - name: CLK1DIV16
+    description: SYSPLLCLK1 is divided by 16.
+    value: 7
+  - name: CLK1DIV18
+    description: SYSPLLCLK1 is divided by 18.
+    value: 8
+  - name: CLK1DIV20
+    description: SYSPLLCLK1 is divided by 20.
+    value: 9
+  - name: CLK1DIV22
+    description: SYSPLLCLK1 is divided by 22.
+    value: 10
+  - name: CLK1DIV24
+    description: SYSPLLCLK1 is divided by 24.
+    value: 11
+  - name: CLK1DIV26
+    description: SYSPLLCLK1 is divided by 26.
+    value: 12
+  - name: CLK1DIV28
+    description: SYSPLLCLK1 is divided by 28.
+    value: 13
+  - name: CLK1DIV30
+    description: SYSPLLCLK1 is divided by 30.
+    value: 14
+  - name: CLK1DIV32
+    description: SYSPLLCLK1 is divided by 32.
+    value: 15
+enum/RDIVCLK2X:
+  bit_size: 4
+  variants:
+  - name: CLK2XDIV1
+    description: SYSPLLCLK1 is divided by 1.
+    value: 0
+  - name: CLK2XDIV2
+    description: SYSPLLCLK1 is divided by 2.
+    value: 1
+  - name: CLK2XDIV3
+    description: SYSPLLCLK1 is divided by 3.
+    value: 2
+  - name: CLK2XDIV4
+    description: SYSPLLCLK1 is divided by 4.
+    value: 3
+  - name: CLK2XDIV5
+    description: SYSPLLCLK1 is divided by 5.
+    value: 4
+  - name: CLK2XDIV6
+    description: SYSPLLCLK1 is divided by 6.
+    value: 5
+  - name: CLK2XDIV7
+    description: SYSPLLCLK1 is divided by 7.
+    value: 6
+  - name: CLK2XDIV8
+    description: SYSPLLCLK1 is divided by 8.
+    value: 7
+  - name: CLK2XDIV9
+    description: SYSPLLCLK1 is divided by 9.
+    value: 8
+  - name: CLK2XDIV10
+    description: SYSPLLCLK1 is divided by 10.
+    value: 9
+  - name: CLK2XDIV11
+    description: SYSPLLCLK1 is divided by 11.
+    value: 10
+  - name: CLK2XDIV12
+    description: SYSPLLCLK1 is divided by 12.
+    value: 11
+  - name: CLK2XDIV13
+    description: SYSPLLCLK1 is divided by 13.
+    value: 12
+  - name: CLK2XDIV14
+    description: SYSPLLCLK1 is divided by 14.
+    value: 13
+  - name: CLK2XDIV15
+    description: SYSPLLCLK1 is divided by 15.
+    value: 14
+  - name: CLK2XDIV16
+    description: SYSPLLCLK1 is divided by 16.
+    value: 15
+enum/RESETCMD_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 228
+enum/RESETLEVEL_LEVEL:
+  bit_size: 3
+  variants:
+  - name: CPU
+    description: Issue a SYSRST (CPU plus peripherals only).
+    value: 0
+  - name: BOOT
+    description: Issue a BOOTRST (CPU, peripherals, and boot configuration routine).
+    value: 1
+  - name: BOOTLOADERENTRY
+    description: Issue a SYSRST and enter the boot strap loader (BSL).
+    value: 2
+  - name: POR
+    description: Issue a power-on reset (POR).
+    value: 3
+  - name: BOOTLOADEREXIT
+    description: Issue a SYSRST and exit the boot strap loader (BSL).
+    value: 4
+enum/REFSEL:
+  bit_size: 1
+  variants:
+  - name: USBSOF
+    description: Use the USB start-of-frame as the reference clock.
+    value: 0
+  - name: LFCLK
+    description: Use LFCLK as the reference clock.
+    value: 1
+enum/SHDNIOREL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 145
+enum/SWDCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 98
+enum/SYSOSCCFG_FREQ:
+  bit_size: 2
+  variants:
+  - name: SYSOSCBASE
+    description: Base frequency (32MHz).
+    value: 0
+  - name: SYSOSC4M
+    description: Low frequency (4MHz).
+    value: 1
+  - name: SYSOSCUSER
+    description: User-trimmed frequency (16 or 24 MHz).
+    value: 2
+enum/SYSOSCFCLCTL_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 42
+enum/SYSOSCFREQ:
+  bit_size: 2
+  variants:
+  - name: SYSOSC32M
+    description: SYSOSC is at base frequency (32MHz).
+    value: 0
+  - name: SYSOSC4M
+    description: SYSOSC is at low frequency (4MHz).
+    value: 1
+  - name: SYSOSCUSER
+    description: SYSOSC is at the user-trimmed frequency (16 or 24MHz).
+    value: 2
+  - name: SYSOSCTURBO
+    description: Reserved.
+    value: 3
+enum/SYSOSCTRIMUSER_FREQ:
+  bit_size: 2
+  variants:
+  - name: SYSOSC16M
+    description: 16MHz user frequency.
+    value: 1
+  - name: SYSOSC24M
+    description: 24MHz user frequency.
+    value: 2
+enum/SYSPLLREF:
+  bit_size: 1
+  variants:
+  - name: SYSOSC
+    description: SYSPLL reference is SYSOSC.
+    value: 0
+  - name: HFCLK
+    description: SYSPLL reference is HFCLK.
+    value: 1
+enum/SYSSTATUSCLR_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 206
+enum/UDIV:
+  bit_size: 2
+  variants:
+  - name: NODIVIDE
+    description: ULPCLK is not divided and is equal to MCLK.
+    value: 0
+  - name: DIVIDE2
+    description: ULPCLK is MCLK/2 (divided-by-2).
+    value: 1
+enum/USBCLKSRC:
+  bit_size: 1
+  variants:
+  - name: USBFLLCLK
+    description: USBCLK source is USBFLL.
+    value: 0
+  - name: SYSPLLOUT1
+    description: USBCLK source is SYSPLLCLK1.
+    value: 1
+enum/USBFLL4HSCLK:
+  bit_size: 1
+  variants:
+  - name: SYSPLL_HFCLK
+    description: HSCLK is sourced from HSCLKCFG.HSCLKSEL.
+    value: 0
+  - name: USBFLL
+    description: HSCLK is sourced from the USBFLL.
+    value: 1
+enum/XT1DRIVE:
+  bit_size: 2
+  variants:
+  - name: LOWESTDRV
+    description: Lowest drive and current.
+    value: 0
+  - name: LOWERDRV
+    description: Lower drive and current.
+    value: 1
+  - name: HIGHERDRV
+    description: Higher drive and current.
+    value: 2
+  - name: HIGHESTDRV
+    description: Highest drive and current.
+    value: 3

--- a/data/registers/sysctl_h321x.yaml
+++ b/data/registers/sysctl_h321x.yaml
@@ -239,6 +239,7 @@ fieldset/CLKSTATUS:
     description: CURHSCLKSEL indicates the current clock source for HSCLK.
     bit_offset: 16
     bit_size: 1
+    enum: CURHSCLKSEL
   - name: CURMCLKSEL
     description: CURMCLKSEL indicates if MCLK is currently sourced from LFCLK.
     bit_offset: 17
@@ -381,10 +382,9 @@ fieldset/HFCLKCLKCFG:
   description: High-frequency clock (HFCLK) configuration.
   fields:
   - name: HFXTTIME
-    description: HFXTTIME specifies the HFXT startup time in 64us resolution. If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time expires.
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
     bit_offset: 0
     bit_size: 8
-    enum: HFXTTIME
   - name: HFXTRSEL
     description: HFXT Range Select.
     bit_offset: 12
@@ -398,9 +398,10 @@ fieldset/HSCLKCFG:
   description: High-speed clock (HSCLK) source selection.
   fields:
   - name: HSCLKSEL
-    description: HSCLKSEL selects the HSCLK source (SYSPLL or HFCLK).
+    description: Selects the HSCLK source. This device has no SYSPLL, so HFCLKCLK is the only source it can select, and software must write it - the reset value leaves HSCLK unsourced.
     bit_offset: 0
     bit_size: 1
+    enum: HSCLKSEL
 fieldset/HSCLKEN:
   description: High-speed clock (HSCLK) source enable/disable.
   fields:
@@ -718,6 +719,15 @@ enum/BORCURTHRESHOLD:
   - name: BORLEVEL3
     description: A BOR3- violation generates a BORLVL interrupt.
     value: 3
+enum/CURHSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: HSCLK is currently sourced from the SYSPLL.
+    value: 0
+  - name: HFCLK
+    description: HSCLK is currently sourced from the HFCLK.
+    value: 1
 enum/DSLEEP:
   bit_size: 2
   variants:
@@ -904,15 +914,6 @@ enum/HFXTRSEL:
   - name: RANGE32TO48
     description: 32MHz < HFXT frequency <= 48MHz.
     value: 3
-enum/HFXTTIME:
-  bit_size: 8
-  variants:
-  - name: MINSTARTTIME
-    description: Minimum startup time (approximatly zero).
-    value: 0
-  - name: MAXSTARTTIME
-    description: Maximum startup time (approximatly 16.32ms).
-    value: 255
 enum/HSCLKMUX:
   bit_size: 1
   variants:
@@ -921,6 +922,15 @@ enum/HSCLKMUX:
     value: 0
   - name: HSCLK
     description: MCLK is sourced from HSCLK.
+    value: 1
+enum/HSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: The SYSPLL position of the mux, and the reset value. This device has no SYSPLL, so HSCLK has no source while this is selected.
+    value: 0
+  - name: HFCLKCLK
+    description: HSCLK is sourced from the HFCLK.
     value: 1
 enum/ID:
   bit_size: 5

--- a/data/registers/sysctl_l110x_l130x_l134x.yaml
+++ b/data/registers/sysctl_l110x_l130x_l134x.yaml
@@ -807,10 +807,6 @@ enum/ID:
   - name: BOOTEXNRST
     description: NRST triggered BOOTRST (&lt;1s hold).
     value: 12
-  # The SVD puts this at 10, copied from SLAU847's RSTCAUSE field description for this SYSCTL
-  # variant. That description contradicts the same TRM's "Reset Causes" table, which lists 10 as
-  # reserved and 13 as the software-triggered BOOTRST, and every other family agrees with the table.
-  # BOOTWWDT0 below was already corrected against that table for the same reason.
   - name: BOOTSW
     description: Software triggered BOOTRST.
     value: 13

--- a/data/registers/sysctl_l110x_l130x_l134x.yaml
+++ b/data/registers/sysctl_l110x_l130x_l134x.yaml
@@ -804,12 +804,16 @@ enum/ID:
   - name: BOOTCLKFAIL
     description: Fatal clock failure.
     value: 9
-  - name: BOOTSW
-    description: Software triggered BOOTRST.
-    value: 10
   - name: BOOTEXNRST
     description: NRST triggered BOOTRST (&lt;1s hold).
     value: 12
+  # The SVD puts this at 10, copied from SLAU847's RSTCAUSE field description for this SYSCTL
+  # variant. That description contradicts the same TRM's "Reset Causes" table, which lists 10 as
+  # reserved and 13 as the software-triggered BOOTRST, and every other family agrees with the table.
+  # BOOTWWDT0 below was already corrected against that table for the same reason.
+  - name: BOOTSW
+    description: Software triggered BOOTRST.
+    value: 13
   - name: BOOTWWDT0
     description: WWDT0 violation.
     value: 14

--- a/data/registers/sysctl_l122x_l222x.yaml
+++ b/data/registers/sysctl_l122x_l222x.yaml
@@ -197,19 +197,19 @@ block/SYSCTL:
   - name: FRXPROTMAINSTART
     description: Flash RX Protection Start Address.
     byte_offset: 12312
-    fieldset: FRXPROTMAINSTART
+    fieldset: FPROTADDR
   - name: FRXPROTMAINEND
     description: Flash RX Protection End Address.
     byte_offset: 12316
-    fieldset: FRXPROTMAINEND
+    fieldset: FPROTADDR
   - name: FIPPROTMAINSTART
     description: Flash IP Protection Start Address.
     byte_offset: 12320
-    fieldset: FIPPROTMAINSTART
+    fieldset: FPROTADDR
   - name: FIPPROTMAINEND
     description: Flash IP Protection End Address.
     byte_offset: 12324
-    fieldset: FIPPROTMAINEND
+    fieldset: FPROTADDR
   - name: FLBANKSWPPOLICY
     description: Flash Bank Swap Policy.
     byte_offset: 12344
@@ -364,18 +364,11 @@ fieldset/FCCCMD:
     bit_offset: 24
     bit_size: 8
     enum: FCCCMD_KEY
-fieldset/FIPPROTMAINEND:
-  description: Flash IP Protection End Address.
+fieldset/FPROTADDR:
+  description: A flash protection boundary address.
   fields:
   - name: ADDR
-    description: Flash IP Protection End Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
-fieldset/FIPPROTMAINSTART:
-  description: Flash IP Protection Start Address.
-  fields:
-  - name: ADDR
-    description: Flash IP Protection Start Address 64B granularity.
+    description: The boundary address, at 64 byte granularity.
     bit_offset: 6
     bit_size: 16
 fieldset/FLBANKSWP:
@@ -392,20 +385,6 @@ fieldset/FLBANKSWPPOLICY:
     description: '1: Disables Policy To Allow Flash Bank Swapping.'
     bit_offset: 0
     bit_size: 1
-fieldset/FRXPROTMAINEND:
-  description: Flash RX Protection End Address.
-  fields:
-  - name: ADDR
-    description: Flash RX Protection End Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
-fieldset/FRXPROTMAINSTART:
-  description: Flash RX Protection Start Address.
-  fields:
-  - name: ADDR
-    description: Flash RX Protection Start Address 64B granularity.
-    bit_offset: 6
-    bit_size: 16
 fieldset/FWENABLE:
   description: Security Firewall Enable Register.
   fields:

--- a/data/registers/sysctl_l122x_l222x.yaml
+++ b/data/registers/sysctl_l122x_l222x.yaml
@@ -487,10 +487,9 @@ fieldset/HFCLKCLKCFG:
   description: High-frequency clock (HFCLK) configuration.
   fields:
   - name: HFXTTIME
-    description: HFXTTIME specifies the HFXT startup time in 64us resolution. If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT will be checked after this time expires.
+    description: HFXT startup time in 64us resolution, from 0 (minimum startup time, approximately zero) to 255 (maximum, approximately 16.32ms). If the HFCLK startup monitor is enabled (HFCLKFLTCHK), HFXT is checked after this time expires.
     bit_offset: 0
     bit_size: 8
-    enum: HFXTTIME
   - name: HFXTRSEL
     description: HFXT Range Select.
     bit_offset: 12
@@ -504,9 +503,10 @@ fieldset/HSCLKCFG:
   description: High-speed clock (HSCLK) source selection.
   fields:
   - name: HSCLKSEL
-    description: HSCLKSEL selects the HSCLK source (SYSPLL or HFCLK).
+    description: Selects the HSCLK source. This device has no SYSPLL, so HFCLKCLK is the only source it can select, and software must write it - the reset value leaves HSCLK unsourced.
     bit_offset: 0
     bit_size: 1
+    enum: HSCLKSEL
 fieldset/HSCLKEN:
   description: High-speed clock (HSCLK) source enable/disable.
   fields:
@@ -1140,15 +1140,6 @@ enum/HFXTRSEL:
   - name: RANGE32TO48
     description: 32MHz &lt; HFXT frequency &lt;= 48MHz.
     value: 3
-enum/HFXTTIME:
-  bit_size: 8
-  variants:
-  - name: MINSTARTTIME
-    description: Minimum startup time (approximatly zero).
-    value: 0
-  - name: MAXSTARTTIME
-    description: Maximum startup time (approximatly 16.32ms).
-    value: 255
 enum/HSCLKMUX:
   bit_size: 1
   variants:
@@ -1157,6 +1148,15 @@ enum/HSCLKMUX:
     value: 0
   - name: HSCLK
     description: MCLK is sourced from HSCLK.
+    value: 1
+enum/HSCLKSEL:
+  bit_size: 1
+  variants:
+  - name: SYSPLL
+    description: The SYSPLL position of the mux, and the reset value. This device has no SYSPLL, so HSCLK has no source while this is selected.
+    value: 0
+  - name: HFCLKCLK
+    description: HSCLK is sourced from the HFCLK.
     value: 1
 enum/ID:
   bit_size: 5

--- a/data/registers/tim_btimer.yaml
+++ b/data/registers/tim_btimer.yaml
@@ -1,0 +1,382 @@
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/CTRREGS:
+  items:
+  - name: CTL0
+    description: CTL0 register.
+    byte_offset: 0
+    fieldset: CTL0
+  - name: LD
+    description: Counter period register.
+    byte_offset: 4
+    fieldset: LD
+  - name: CNT
+    description: Counter register.
+    byte_offset: 8
+    fieldset: CNT
+block/GEN_EVENT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: INT
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: STAT
+block/TIM:
+  description: PERIPHERALREGION.
+  items:
+  - name: FSUB
+    description: Subscriber Port 0.
+    byte_offset: 1024
+    fieldset: FPORT
+  - name: FPUB
+    description: Publisher Port 0.
+    byte_offset: 1092
+    fieldset: FPORT
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: PDBGCTL
+    description: Peripheral Debug Control.
+    byte_offset: 4120
+    fieldset: PDBGCTL
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: GEN_EVENT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4176
+    block: GEN_EVENT
+  - name: EVT_MODE
+    description: Event Mode.
+    byte_offset: 4320
+    access: Read
+    fieldset: EVT_MODE
+  - name: CTRREGS
+    description: One independent counter. Every device with a TIMB implements two, which is what TI's own `BTIMER_Regs` declares; the register array itself runs to eight.
+    array:
+      len: 2
+      stride: 256
+    byte_offset: 4352
+    block: CTRREGS
+fieldset/CNT:
+  description: Counter register.
+  fields:
+  - name: VALUE
+    description: Counter Value.
+    bit_offset: 0
+    bit_size: 16
+fieldset/CTL0:
+  description: CTL0 register.
+  fields:
+  - name: EN
+    description: Counter Enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: STARTSEL
+    description: Selects the source used to start the counter.
+    bit_offset: 4
+    bit_size: 4
+  - name: STOPSEL
+    description: Selects the source used to stop the counter.
+    bit_offset: 8
+    bit_size: 4
+  - name: RESETSEL
+    description: Selects the source used to reset the counter.
+    bit_offset: 12
+    bit_size: 4
+  - name: CLKSEL
+    description: Clock sources.
+    bit_offset: 16
+    bit_size: 4
+fieldset/EVT_MODE:
+  description: Event Mode.
+  fields:
+  - name: CPU_INT_CFG
+    description: Event line mode select for event corresponding to CPU_INT.
+    bit_offset: 0
+    bit_size: 2
+    enum: EVT_CFG
+  - name: GEN_EVENT_CFG
+    description: Event line mode select for event corresponding to GEN_EVENT.
+    bit_offset: 2
+    bit_size: 2
+    enum: EVT_CFG
+fieldset/FPORT:
+  description: Publisher or subscriber port.
+  fields:
+  - name: CHANID
+    description: 0 = disconnected. 1-15 = connected to channelID = CHANID.
+    bit_offset: 0
+    bit_size: 4
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    description: Interrupt index status.
+    bit_offset: 0
+    bit_size: 10
+    enum: IIDX_STAT
+fieldset/INT:
+  description: Interrupt mask, status, set or clear.
+  fields:
+  - name: CNTOVF
+    description: Counter period match.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 8
+      stride: 3
+  - name: CNTSTRT
+    description: Counter start.
+    bit_offset: 1
+    bit_size: 1
+    array:
+      len: 8
+      stride: 3
+  - name: CNTSTOP
+    description: Counter stop.
+    bit_offset: 2
+    bit_size: 1
+    array:
+      len: 8
+      stride: 3
+fieldset/LD:
+  description: Counter period register.
+  fields:
+  - name: VAL
+    description: Period value.
+    bit_offset: 0
+    bit_size: 16
+fieldset/PDBGCTL:
+  description: Peripheral Debug Control.
+  fields:
+  - name: FREE
+    description: Free run control.
+    bit_offset: 0
+    bit_size: 1
+  - name: SOFT
+    description: Soft halt boundary control. This function is only available, if [FREE] is set to 'STOP'.
+    bit_offset: 1
+    bit_size: 1
+    enum: SOFT
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+fieldset/STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+enum/EVT_CFG:
+  bit_size: 2
+  variants:
+  - name: DISABLE
+    description: The interrupt or event line is disabled.
+    value: 0
+  - name: SOFTWARE
+    description: The interrupt or event line is in software mode. Software must clear the RIS.
+    value: 1
+  - name: HARDWARE
+    description: The interrupt or event line is in hardware mode. The hardware (another module) clears automatically the associated RIS flag.
+    value: 2
+enum/IIDX_STAT:
+  bit_size: 10
+  variants:
+  - name: NO_INTR
+    description: No bit is set means there is no pending interrupt request.
+    value: 0
+  - name: CNT0OVF
+    description: Counter0 period match interrupt.
+    value: 1
+  - name: CNT0STRT
+    description: Counter 0 start.
+    value: 2
+  - name: CNT0STOP
+    description: Counter0 stop.
+    value: 3
+  - name: CNT1OVF
+    description: Counter1 period match interrupt.
+    value: 4
+  - name: CNT1STRT
+    description: Counter 1 start.
+    value: 5
+  - name: CNT1STOP
+    description: Counter1 stop.
+    value: 6
+  - name: CNT2OVF
+    description: Counter2 period match interrupt.
+    value: 7
+  - name: CNT2STRT
+    description: Counter 2 start.
+    value: 8
+  - name: CNT2STOP
+    description: Counter2 stop.
+    value: 9
+  - name: CNT3OVF
+    description: Counter3 period match interrupt.
+    value: 10
+  - name: CNT3STRT
+    description: Counter 3 start.
+    value: 11
+  - name: CNT3STOP
+    description: Counter3 stop.
+    value: 12
+  - name: CNT4OVF
+    description: Counter4 period match interrupt.
+    value: 13
+  - name: CNT4STRT
+    description: Counter 4 start.
+    value: 14
+  - name: CNT4STOP
+    description: Counter4 stop.
+    value: 15
+  - name: CNT5OVF
+    description: Counter5 period match interrupt.
+    value: 16
+  - name: CNT5STRT
+    description: Counter 5 start.
+    value: 17
+  - name: CNT5STOP
+    description: Counter5 stop.
+    value: 18
+  - name: CNT6OVF
+    description: Counter6 period match interrupt.
+    value: 19
+  - name: CNT6STRT
+    description: Counter 6 start.
+    value: 20
+  - name: CNT6STOP
+    description: Counter6 stop.
+    value: 21
+  - name: CNT7OVF
+    description: Counter7 period match interrupt.
+    value: 22
+  - name: CNT7STRT
+    description: Counter 7 start.
+    value: 23
+  - name: CNT7STOP
+    description: Counter7 stop.
+    value: 24
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177
+enum/SOFT:
+  bit_size: 1
+  variants:
+  - name: IMMEDIATE
+    description: The peripheral will halt immediately, even if the resultant state will result in corruption if the system is restarted.
+    value: 0
+  - name: DELAYED
+    description: The peripheral blocks the debug freeze until it has reached a boundary where it can resume without corruption.
+    value: 1

--- a/data/registers/tim_btimer.yaml
+++ b/data/registers/tim_btimer.yaml
@@ -129,9 +129,9 @@ block/TIM:
     access: Read
     fieldset: EVT_MODE
   - name: CTRREGS
-    description: One independent counter. Every device with a TIMB implements two, which is what TI's own `BTIMER_Regs` declares; the register array itself runs to eight.
+    description: One independent counter. The array is the eight the TRM documents and the interrupt registers have bits for; how many a device implements is `Timer::counters`, which is 4 on the G-series instances and 2 on the L-series ones.
     array:
-      len: 2
+      len: 8
       stride: 256
     byte_offset: 4352
     block: CTRREGS

--- a/data/registers/tim_v1.yaml
+++ b/data/registers/tim_v1.yaml
@@ -119,62 +119,62 @@ block/CPU_INT:
     description: Interrupt index.
     byte_offset: 0
     access: Read
-    fieldset: CPU_INT_IIDX
+    fieldset: IIDX
   - name: IMASK
     description: Interrupt mask.
     byte_offset: 8
-    fieldset: CPU_INT
+    fieldset: INT
   - name: RIS
     description: Raw interrupt status.
     byte_offset: 16
     access: Read
-    fieldset: CPU_INT
+    fieldset: INT
   - name: MIS
     description: Masked interrupt status.
     byte_offset: 24
     access: Read
-    fieldset: CPU_INT
+    fieldset: INT
   - name: ISET
     description: Interrupt set.
     byte_offset: 32
     access: Write
-    fieldset: CPU_INT
+    fieldset: INT
   - name: ICLR
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: CPU_INT
+    fieldset: INT
 block/GEN_EVENT:
   items:
   - name: IIDX
     description: Interrupt index.
     byte_offset: 0
     access: Read
-    fieldset: GEN_EVENT_IIDX
+    fieldset: IIDX
   - name: IMASK
     description: Interrupt mask.
     byte_offset: 8
-    fieldset: GEN_EVENT_INT
+    fieldset: INT
   - name: RIS
     description: Raw interrupt status.
     byte_offset: 16
     access: Read
-    fieldset: GEN_EVENT_INT
+    fieldset: INT
   - name: MIS
     description: Masked interrupt status.
     byte_offset: 24
     access: Read
-    fieldset: GEN_EVENT_INT
+    fieldset: INT
   - name: ISET
     description: Interrupt set.
     byte_offset: 32
     access: Write
-    fieldset: GEN_EVENT_INT
+    fieldset: INT
   - name: ICLR
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: GEN_EVENT_INT
+    fieldset: INT
 block/GPRCM:
   items:
   - name: PWREN
@@ -332,12 +332,12 @@ fieldset/CCCTL:
     description: 'Load Condition. #br# Specifies the condition that generates a load pulse.'
     bit_offset: 8
     bit_size: 3
-    enum: LCOND
+    enum: LZCOND
   - name: ZCOND
     description: 'Zero Condition. #br# This field specifies the condition that generates a zero pulse.'
     bit_offset: 12
     bit_size: 3
-    enum: ZCOND
+    enum: LZCOND
   - name: COC
     description: 'Capture or Compare. #br# Specifies whether the corresponding CC register is used as a capture register or a compare register (never both).'
     bit_offset: 17
@@ -347,7 +347,7 @@ fieldset/CCCTL:
     description: Capture and Compare Update Method This field controls how updates to the shadow capture and compare register are performed (when operating in compare mode, COC=0).
     bit_offset: 18
     bit_size: 3
-    enum: CCUPD
+    enum: UPD
   - name: CC2SELU
     description: Selects the source second CCU event.
     bit_offset: 22
@@ -361,7 +361,7 @@ fieldset/CCCTL:
     description: CCACT shadow register Update Method This field controls how updates to the CCACT shadow register are performed.
     bit_offset: 26
     bit_size: 3
-    enum: CCACTUPD
+    enum: UPD
   - name: CC2SELD
     description: Selects the source second CCD event.
     bit_offset: 29
@@ -420,93 +420,57 @@ fieldset/CPSV:
     description: Current Prescale Count Value.
     bit_offset: 0
     bit_size: 8
-fieldset/CPU_INT:
-  description: Interrupt clear.
+fieldset/INT:
+  description: The timer's events. Shared by IMASK, RIS, MIS, ISET and ICLR of both the CPU interrupt and the generic event blocks.
   fields:
   - name: Z
-    description: Zero event CLEAR.
+    description: Zero event.
     bit_offset: 0
     bit_size: 1
   - name: L
-    description: Load event CLEAR.
+    description: Load event.
     bit_offset: 1
     bit_size: 1
-  - name: CCD0
-    description: Capture or compare down event CLEAR.
+  - name: CCD
+    description: Capture or compare down event. Channels 4 and 5 are compare only, and sit above the CCU bits rather than next to CCD0-3.
     bit_offset: 4
     bit_size: 1
-  - name: CCD1
-    description: Capture or compare down event CLEAR.
-    bit_offset: 5
-    bit_size: 1
-  - name: CCD2
-    description: Capture or compare down event CLEAR.
-    bit_offset: 6
-    bit_size: 1
-  - name: CCD3
-    description: Capture or compare down event CLEAR.
-    bit_offset: 7
-    bit_size: 1
-  - name: CCU0
-    description: Capture or compare up event CLEAR.
+    array:
+      offsets: [0, 1, 2, 3, 8, 9]
+  - name: CCU
+    description: Capture or compare up event. Channels 4 and 5 are compare only, and sit above the CCD4 and CCD5 bits.
     bit_offset: 8
     bit_size: 1
-  - name: CCU1
-    description: Capture or compare up event CLEAR.
-    bit_offset: 9
-    bit_size: 1
-  - name: CCU2
-    description: Capture or compare up event CLEAR.
-    bit_offset: 10
-    bit_size: 1
-  - name: CCU3
-    description: Capture or compare up event CLEAR.
-    bit_offset: 11
-    bit_size: 1
-  - name: CCD4
-    description: Compare down event 4 CLEAR.
-    bit_offset: 12
-    bit_size: 1
-  - name: CCD5
-    description: Compare down event 5 CLEAR.
-    bit_offset: 13
-    bit_size: 1
-  - name: CCU4
-    description: Compare up event 4 CLEAR.
-    bit_offset: 14
-    bit_size: 1
-  - name: CCU5
-    description: Compare up event 5 CLEAR.
-    bit_offset: 15
-    bit_size: 1
+    array:
+      offsets: [0, 1, 2, 3, 6, 7]
   - name: F
-    description: Fault event CLEAR.
+    description: Fault event.
     bit_offset: 24
     bit_size: 1
   - name: TOV
-    description: Trigger Overflow event CLEAR.
+    description: Trigger Overflow event.
     bit_offset: 25
     bit_size: 1
   - name: REPC
-    description: Repeat Counter Zero event CLEAR.
+    description: Repeat Counter Zero event.
     bit_offset: 26
     bit_size: 1
   - name: DC
-    description: Direction change event
+    description: Direction change event.
     bit_offset: 27
     bit_size: 1
   - name: QEIERR
-    description: QEIERR event
+    description: QEIERR event.
     bit_offset: 28
     bit_size: 1
-fieldset/CPU_INT_IIDX:
+fieldset/IIDX:
   description: Interrupt index.
   fields:
   - name: STAT
     description: Interrupt index status.
     bit_offset: 0
     bit_size: 8
-    enum: CPU_INT_IIDX_STAT
+    enum: IIDX_STAT
 fieldset/CTRCTL:
   description: Counter Control Register.
   fields:
@@ -543,7 +507,7 @@ fieldset/CTRCTL:
     description: Debug Resume Behavior This bit specifies what the device does following the release/exit of debug mode.
     bit_offset: 17
     bit_size: 1
-    enum: DRB
+    enum: RB
   - name: FB
     description: Fault Behavior This bit specifies whether the counter continues running or suspends during a fault mode. There is a separate control under REPEAT to indicate whether counting is to suspend at next Counter==0.
     bit_offset: 18
@@ -553,7 +517,7 @@ fieldset/CTRCTL:
     description: Fault Resume Behavior This bit specifies what the device does following the release/exit of fault condition.
     bit_offset: 19
     bit_size: 1
-    enum: FRB
+    enum: RB
   - name: SLZERCNEZ
     description: Suppress Load and Zero Events if Repeat Counter is Not Equal to Zero. This bit suppresses the generation of the Z (zero) and L (load) events from the counter when the repeat counter (RC) value is not 0.
     bit_offset: 23
@@ -664,30 +628,20 @@ fieldset/FCTL:
     description: Trigger Fault Input Mask Specifies whether the selected trigger participates as a fault input. If enabled and the trigger asserts, the trigger is treated as a fault.
     bit_offset: 7
     bit_size: 1
-  - name: FSENAC0
-    description: Specifies whether the COMP0 output high/low is treated as fault condition.
+  - name: FSENAC
+    description: Specifies whether the COMPn output high/low is treated as fault condition.
     bit_offset: 8
     bit_size: 1
-  - name: FSENAC1
-    description: Specifies whether the COMP1 output high/low is treated as fault condition.
-    bit_offset: 9
-    bit_size: 1
-  - name: FSENAC2
-    description: Specifies whether the COMP2 output high/low is treated as fault condition.
-    bit_offset: 10
-    bit_size: 1
-  - name: FSENEXT0
-    description: Specifies whether the external fault pin0 high/low is treated as fault condition.
+    array:
+      len: 3
+      stride: 1
+  - name: FSENEXT
+    description: Specifies whether the external fault pin n high/low is treated as fault condition.
     bit_offset: 11
     bit_size: 1
-  - name: FSENEXT1
-    description: Specifies whether the external fault pin1 high/low is treated as fault condition.
-    bit_offset: 12
-    bit_size: 1
-  - name: FSENEXT2
-    description: Specifies whether the external fault pin2 high/low is treated as fault condition.
-    bit_offset: 13
-    bit_size: 1
+    array:
+      len: 3
+      stride: 1
 fieldset/FIFCTL:
   description: Fault input Filter control register.
   fields:
@@ -700,7 +654,7 @@ fieldset/FIFCTL:
     description: Consecutive Period/Voting Select This bit controls whether the input filter uses a stricter consecutive period count or majority voting.
     bit_offset: 3
     bit_size: 1
-    enum: FIFCTL_CPV
+    enum: CPV
   - name: FILTEN
     description: Filter Enable This bit controls whether the input is filtered by the input filter or bypasses to go directly to the optional pre-scale filter and then to the edge detect.
     bit_offset: 4
@@ -749,93 +703,6 @@ fieldset/GCTL:
   - name: SHDWLDEN
     description: Enables shadow to active load of bufferred registers and register fields.
     bit_offset: 0
-    bit_size: 1
-fieldset/GEN_EVENT_IIDX:
-  description: Interrupt index.
-  fields:
-  - name: STAT
-    description: Interrupt index status.
-    bit_offset: 0
-    bit_size: 8
-    enum: GEN_EVENT_IIDX_STAT
-fieldset/GEN_EVENT_INT:
-  description: Interrupt clear.
-  fields:
-  - name: Z
-    description: Zero event CLEAR.
-    bit_offset: 0
-    bit_size: 1
-  - name: L
-    description: Load event CLEAR.
-    bit_offset: 1
-    bit_size: 1
-  - name: CCD0
-    description: Capture or compare down event CLEAR.
-    bit_offset: 4
-    bit_size: 1
-  - name: CCD1
-    description: Capture or compare down event CLEAR.
-    bit_offset: 5
-    bit_size: 1
-  - name: CCD2
-    description: Capture or compare down event CLEAR.
-    bit_offset: 6
-    bit_size: 1
-  - name: CCD3
-    description: Capture or compare down event CLEAR.
-    bit_offset: 7
-    bit_size: 1
-  - name: CCU0
-    description: Capture or compare up event CLEAR.
-    bit_offset: 8
-    bit_size: 1
-  - name: CCU1
-    description: Capture or compare up event CLEAR.
-    bit_offset: 9
-    bit_size: 1
-  - name: CCU2
-    description: Capture or compare up event CLEAR.
-    bit_offset: 10
-    bit_size: 1
-  - name: CCU3
-    description: Capture or compare up event CLEAR.
-    bit_offset: 11
-    bit_size: 1
-  - name: CCD4
-    description: Compare down event 4 CLEAR.
-    bit_offset: 12
-    bit_size: 1
-  - name: CCD5
-    description: Compare down event 5 CLEAR.
-    bit_offset: 13
-    bit_size: 1
-  - name: CCU4
-    description: Compare up event 4 CLEAR.
-    bit_offset: 14
-    bit_size: 1
-  - name: CCU5
-    description: Compare up event 5 CLEAR.
-    bit_offset: 15
-    bit_size: 1
-  - name: F
-    description: Fault event CLEAR.
-    bit_offset: 24
-    bit_size: 1
-  - name: TOV
-    description: Trigger Overflow event CLEAR.
-    bit_offset: 25
-    bit_size: 1
-  - name: REPC
-    description: Repeat Counter Zero event CLEAR.
-    bit_offset: 26
-    bit_size: 1
-  - name: DC
-    description: Direction change event
-    bit_offset: 27
-    bit_size: 1
-  - name: QEIERR
-    description: QEIERR event
-    bit_offset: 28
     bit_size: 1
 fieldset/IFCTL:
   description: Input Filter Control Register 0/1.
@@ -1050,30 +917,6 @@ enum/CC2SELU:
   - name: SEL_CCU5
     description: Selects CCU from CC5.
     value: 5
-enum/CCACTUPD:
-  bit_size: 3
-  variants:
-  - name: Immediately
-    description: Value written to the CCACT register has immediate effect.
-    value: 0
-  - name: Zero_EVT
-    description: Following a zero event (CTR=0) Writes to the CCACTx_y register are stored in shadow register and transferred to CCACTx_y in the TIMCLK cycle following CTR equals 0.
-    value: 1
-  - name: Compare_Down_EVT
-    description: Following a CCD event (CTR=CC_xy) Writes to the CCACTx_y register are stored in shadow register and transferred to CCACTx_y in the TIMCLK cycle following CTR equals the CCx_y register value.
-    value: 2
-  - name: Compare_UP_EVT
-    description: Following a CCU event (CTR=CC_xy) Writes to the CCACTx_y register are stored in shadow register and transferred to CCACTx_y in the TIMCLK cycle following CTR equals the CCx_y register value.
-    value: 3
-  - name: ZERO_LOAD_EVT
-    description: Following a zero event (CTR=0) or load event (CTR = LOAD) Writes to the CCACTx_y register are stored in shadow register and transferred to CCACTx_y in the TIMCLK cycle following CTR equals 0 or CTR. Equals LDn. Note this update mechanism is defined for use only in configurations using up/down counting. This mode is not intended for use in down count configurations.
-    value: 4
-  - name: ZERO_RC_ZERO_EVT
-    description: Following a zero event (CTR=0) with repeat count also zero (RC=0). Writes to the CCACTx_y register are stored in shadow register and transferred to CCACTx_y in the TIMCLK cycle following CTR equals 0 and if RC equal 0.
-    value: 5
-  - name: TRIG
-    description: On a TRIG pulse, the value stored in CCACT_xy shadow register is loaded into CCACT_xy register.
-    value: 6
 enum/CCOND:
   bit_size: 3
   variants:
@@ -1131,7 +974,7 @@ enum/CCPO:
   - name: CNTDIR
     description: Counter direction.
     value: 13
-enum/CCUPD:
+enum/UPD:
   bit_size: 3
   variants:
   - name: Immediately
@@ -1176,7 +1019,7 @@ enum/COC:
   - name: CAPTURE
     description: Capture.
     value: 1
-enum/CPU_INT_IIDX_STAT:
+enum/IIDX_STAT:
   bit_size: 8
   variants:
   - name: NO_INTR
@@ -1239,15 +1082,6 @@ enum/CPU_INT_IIDX_STAT:
   - name: QEIERR
     description: Interrupt Source:QEI Incorrect state transition error (QEIERR).
     value: 29
-enum/CPV:
-  bit_size: 1
-  variants:
-  - name: Consecutive
-    description: Consecutive Periods The input must be at a specific logic level for the period defined by FP before it is passed to the filter output.
-    value: 0
-  - name: Voting
-    description: Voting The filter ignores one clock of opposite logic over the filter period. I.e. Over FP samples of the input, up to 1 sample may be of an opposite logic value (glitch) without affecting the output.
-    value: 1
 enum/CVAE:
   bit_size: 2
   variants:
@@ -1281,7 +1115,7 @@ enum/CxC:
   - name: QEI_3INP
     description: Controlled by 3-input QEI mode This value exists when TIMER support QEI feature.
     value: 5
-enum/DRB:
+enum/RB:
   bit_size: 1
   variants:
   - name: RESUME
@@ -1425,7 +1259,7 @@ enum/FB:
   - name: SUSP_COUNT
     description: Suspends counting.
     value: 1
-enum/FIFCTL_CPV:
+enum/CPV:
   bit_size: 1
   variants:
   - name: CONSEC_PER
@@ -1473,78 +1307,6 @@ enum/FP:
   - name: _8
     description: The division factor is 8.
     value: 2
-enum/FRB:
-  bit_size: 1
-  variants:
-  - name: RESUME
-    description: Resume counting.
-    value: 0
-  - name: CVAE_ACTION
-    description: Perform the action as specified by the CVAE field.
-    value: 1
-enum/GEN_EVENT_IIDX_STAT:
-  bit_size: 8
-  variants:
-  - name: NO_INTR
-    description: No interrupt pending.
-    value: 0
-  - name: Z
-    description: 'Interrupt Source: Zero event (Z).'
-    value: 1
-  - name: L
-    description: 'nterrupt Source: Load event (L).'
-    value: 2
-  - name: CCD0
-    description: 'Interrupt Source: Capture or compare down event (CCD0).'
-    value: 5
-  - name: CCD1
-    description: 'Interrupt Source: Capture or compare down event (CCD1).'
-    value: 6
-  - name: CCD2
-    description: 'Interrupt Source: Capture or compare down event (CCD2).'
-    value: 7
-  - name: CCD3
-    description: 'Interrupt Source: Capture or compare down event (CCD3).'
-    value: 8
-  - name: CCU0
-    description: 'Interrupt Source: Capture or compare up event (CCU0).'
-    value: 9
-  - name: CCU1
-    description: 'Interrupt Source: Capture or compare up event (CCU1).'
-    value: 10
-  - name: CCU2
-    description: 'Interrupt Source: Capture or compare up event (CCU2).'
-    value: 11
-  - name: CCU3
-    description: 'Interrupt Source: Capture or compare up event (CCU3).'
-    value: 12
-  - name: CCD4
-    description: 'Interrupt Source: Compare down event (CCD4).'
-    value: 13
-  - name: CCD5
-    description: 'Interrupt Source: Compare down event (CCD5).'
-    value: 14
-  - name: CCU4
-    description: 'Interrupt Source: Compare down event (CCU4).'
-    value: 15
-  - name: CCU5
-    description: 'Interrupt Source: Compare down event (CCU5).'
-    value: 16
-  - name: F
-    description: 'Interrupt Source: Fault Event generated an interrupt. (F).'
-    value: 25
-  - name: TOV
-    description: 'Interrupt Source: Trigger overflow (TOV).'
-    value: 26
-  - name: REPC
-    description: 'Interrupt Source: Repeat Counter Zero (REPC).'
-    value: 27
-  - name: DC
-    description: 'Interrupt Source: Direction Change (DC).'
-    value: 28
-  - name: QEIERR
-    description: Interrupt Source:QEI Incorrect state transition error (QEIERR).
-    value: 29
 enum/ISEL:
   bit_size: 4
   variants:
@@ -1578,7 +1340,7 @@ enum/ISEL:
   - name: COMP2
     description: Comparator 2 output.
     value: 9
-enum/LCOND:
+enum/LZCOND:
   bit_size: 3
   variants:
   - name: CC_TRIG_NO_EFFECT
@@ -1642,18 +1404,3 @@ enum/SWFRCACT:
   - name: CCP_LOW
     description: CCP output value is set low.
     value: 2
-enum/ZCOND:
-  bit_size: 3
-  variants:
-  - name: CC_TRIG_NO_EFFECT
-    description: CCP edges have no effect.
-    value: 0
-  - name: CC_TRIG_RISE
-    description: Rising edge of CCP or trigger assertion edge.
-    value: 1
-  - name: CC_TRIG_FALL
-    description: Falling edge of CCP or trigger de-assertion edge.
-    value: 2
-  - name: CC_TRIG_EDGE
-    description: Either edge of CCP or trigger change (assertion/de-assertion edge).
-    value: 3

--- a/data/registers/uart_v1.yaml
+++ b/data/registers/uart_v1.yaml
@@ -307,14 +307,13 @@ fieldset/CPU_INT:
     description: Clear Positive Edge on UARTxRXD Interrupt.
     bit_offset: 6
     bit_size: 1
-  - name: LINC0
-    description: Clear LIN Capture 0 / Match Interrupt.
+  - name: LINC
+    description: 'LIN capture interrupt. Index 0 is the capture-or-match interrupt on the falling RXD edge, index 1 the capture interrupt on the rising edge.'
     bit_offset: 7
     bit_size: 1
-  - name: LINC1
-    description: Clear LIN Capture 1 Interrupt.
-    bit_offset: 8
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: LINOVF
     description: Clear LIN Hardware Counter Overflow Interrupt.
     bit_offset: 9

--- a/data/registers/unicomm_v1.yaml
+++ b/data/registers/unicomm_v1.yaml
@@ -1,0 +1,140 @@
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: CLKCFG
+    description: Peripheral Clock Configuration Register.
+    byte_offset: 8
+    fieldset: CLKCFG
+  - name: STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: STAT
+block/UNICOMM:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    array:
+      len: 1
+      stride: 24
+    byte_offset: 2048
+    block: GPRCM
+  - name: IPMODE
+    description: Mode Selection Register.
+    byte_offset: 4352
+    fieldset: IPMODE
+  - name: BASEADDR
+    description: Base address of the SRAM range DMA may read and write, used in security configuration.
+    byte_offset: 4356
+    fieldset: BASEADDR
+  - name: RANGE
+    description: Size of the SRAM range DMA may read and write, used in security configuration.
+    byte_offset: 4360
+    fieldset: RANGE
+fieldset/BASEADDR:
+  description: Base address of the SRAM range DMA may read and write.
+  fields:
+  - name: ADDR
+    description: Base address, in units of 64 bytes.
+    bit_offset: 6
+    bit_size: 25
+fieldset/CLKCFG:
+  description: Peripheral Clock Configuration Register.
+  fields:
+  - name: BLOCKASYNC
+    description: Async Clock Request is blocked from starting SYSOSC or forcing bus clock to 32MHz.
+    bit_offset: 8
+    bit_size: 1
+  - name: KEY
+    description: KEY to Allow State Change A9h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: CLKCFG_KEY
+fieldset/IPMODE:
+  description: Mode Selection Register.
+  fields:
+  - name: SELECT
+    description: Which of the instance's register maps is active. Only the modes `Peripheral::unicomm` reports are implemented; an instance which implements one has no choice to make and ignores this register.
+    bit_offset: 0
+    bit_size: 2
+    enum: SELECT
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change 26h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RANGE:
+  description: Size of the SRAM range DMA may read and write.
+  fields:
+  - name: RANGE
+    description: Range in bytes.
+    bit_offset: 0
+    bit_size: 20
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key B1h = KEY to allow write access to this register
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+fieldset/STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+enum/CLKCFG_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 169
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177
+enum/SELECT:
+  bit_size: 2
+  variants:
+  - name: UART
+    description: The UART register map is active.
+    value: 0
+  - name: SPI
+    description: The SPI register map is active.
+    value: 1
+  - name: I2C_CONTROLLER
+    description: The I2C controller register map is active.
+    value: 2
+  - name: I2C_TARGET
+    description: The I2C target register map is active. TI's headers call this the peripheral mode.
+    value: 3

--- a/data/registers/unicommi2cc_v1.yaml
+++ b/data/registers/unicommi2cc_v1.yaml
@@ -28,7 +28,7 @@ block/CPU_INT:
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: ICLR
+    fieldset: CPU_INT
 block/DMA_TRIG0:
   items:
   - name: IMASK
@@ -333,69 +333,6 @@ fieldset/GFCTL:
   - name: AGFEN
     description: Analog Glitch Suppression Enable.
     bit_offset: 8
-    bit_size: 1
-fieldset/ICLR:
-  description: Interrupt clear.
-  fields:
-  - name: RXDONE
-    description: Receive Data Interrupt Signals that a byte has been received.
-    bit_offset: 0
-    bit_size: 1
-  - name: TXDONE
-    description: Transmit Transaction completed Interrupt.
-    bit_offset: 1
-    bit_size: 1
-  - name: RXTRG
-    description: Receive Trigger.
-    bit_offset: 2
-    bit_size: 1
-  - name: TXTRG
-    description: Transmit FIFO Trigger.
-    bit_offset: 3
-    bit_size: 1
-  - name: RXFULL
-    description: RXFIFO full event.
-    bit_offset: 4
-    bit_size: 1
-  - name: TXEMPTY
-    description: Transmit FIFO Empty interrupt mask. This interrupt is set if all data in the Transmit FIFO have been shifted out and the transmit goes into idle mode.
-    bit_offset: 5
-    bit_size: 1
-  - name: NACK
-    description: Address/Data NACK Interrupt.
-    bit_offset: 7
-    bit_size: 1
-  - name: START
-    description: START Detection Interrupt.
-    bit_offset: 8
-    bit_size: 1
-  - name: STOP
-    description: STOP Detection Interrupt.
-    bit_offset: 9
-    bit_size: 1
-  - name: ARBLOST
-    description: Arbitration Lost Interrupt.
-    bit_offset: 10
-    bit_size: 1
-  - name: PEC_RX_ERR
-    description: RX Pec Error Interrupt.
-    bit_offset: 11
-    bit_size: 1
-  - name: TIMEOUTA
-    description: Timeout A interrupt.
-    bit_offset: 12
-    bit_size: 1
-  - name: TIMEOUTB
-    description: Timeout B Interrupt.
-    bit_offset: 13
-    bit_size: 1
-  - name: DMA_DONE_RX
-    description: DMA Done on Event Channel RX.
-    bit_offset: 15
-    bit_size: 1
-  - name: DMA_DONE_TX
-    description: DMA Done on Event Channel TX.
-    bit_offset: 16
     bit_size: 1
 fieldset/IFLS:
   description: Interrupt FIFO Level Select Register.

--- a/data/registers/unicommi2cc_v1.yaml
+++ b/data/registers/unicommi2cc_v1.yaml
@@ -1,0 +1,732 @@
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: CPU_INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: CPU_INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: CPU_INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: CPU_INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: ICLR
+block/DMA_TRIG0:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG0
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG0
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG0
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG0
+block/DMA_TRIG1:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG1
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG1
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG1
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG1
+block/UNICOMMI2CC:
+  description: PERIPHERALREGION.
+  items:
+  - name: CLKDIV
+    description: Clock Divider.
+    byte_offset: 4096
+    fieldset: CLKDIV
+  - name: CLKSEL
+    description: Clock Select for Ultra Low Power peripherals.
+    byte_offset: 4104
+    fieldset: CLKSEL
+  - name: PDBGCTL
+    description: Peripheral Debug Control.
+    byte_offset: 4120
+    fieldset: PDBGCTL
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: DMA_TRIG1
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4176
+    block: DMA_TRIG1
+  - name: DMA_TRIG0
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4224
+    block: DMA_TRIG0
+  - name: INTCTL
+    description: Interrupt control register.
+    byte_offset: 4324
+    access: Write
+    fieldset: INTCTL
+  - name: CTR
+    description: Control Register.
+    byte_offset: 4352
+    fieldset: CTR
+  - name: CR
+    description: Configuration.
+    byte_offset: 4356
+    fieldset: CR
+  - name: SR
+    description: Status Register.
+    byte_offset: 4360
+    access: Read
+    fieldset: SR
+  - name: IFLS
+    description: Interrupt FIFO Level Select Register.
+    byte_offset: 4364
+    fieldset: IFLS
+  - name: TPR
+    description: Timer Period.
+    byte_offset: 4368
+    fieldset: TPR
+  - name: GFCTL
+    description: I2C Glitch Filter Control.
+    byte_offset: 4376
+    fieldset: GFCTL
+  - name: BMON
+    description: Bus Monitor.
+    byte_offset: 4380
+    access: Read
+    fieldset: BMON
+  - name: TXDATA
+    description: TXData.
+    byte_offset: 4384
+    access: Write
+    fieldset: TXDATA
+  - name: RXDATA
+    description: RXData.
+    byte_offset: 4388
+    access: Read
+    fieldset: RXDATA
+  - name: PECSR
+    description: PEC status register.
+    byte_offset: 4392
+    access: Read
+    fieldset: PECSR
+  - name: TA
+    description: Target Address Register.
+    byte_offset: 4428
+    fieldset: TA
+  - name: TIMEOUT_CNT
+    description: I2C Timeout Count Register.
+    byte_offset: 4432
+    access: Read
+    fieldset: TIMEOUT_CNT
+  - name: TIMEOUT_CTL
+    description: I2C Timeout Count Control Register.
+    byte_offset: 4436
+    fieldset: TIMEOUT_CTL
+  - name: PECCTL
+    description: I2C PEC control register.
+    byte_offset: 4440
+    fieldset: PECCTL
+fieldset/BMON:
+  description: Bus Monitor.
+  fields:
+  - name: SCL
+    description: I2C SCL Status.
+    bit_offset: 0
+    bit_size: 1
+  - name: SDA
+    description: I2C SDA Status.
+    bit_offset: 1
+    bit_size: 1
+fieldset/CLKDIV:
+  description: Clock Divider.
+  fields:
+  - name: RATIO
+    description: 'Divide ratio of the module clock, as the divisor minus one: 0 divides by 1 and 63 by 64.'
+    bit_offset: 0
+    bit_size: 6
+fieldset/CLKSEL:
+  description: Clock Select for Ultra Low Power peripherals.
+  fields:
+  - name: MFCLK_SEL
+    description: Selects MFCLK as clock source if enabled.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSCLK_SEL
+    description: Selects BUS CLK as clock source if enabled.
+    bit_offset: 3
+    bit_size: 1
+fieldset/CPU_INT:
+  description: Interrupt mask.
+  fields:
+  - name: RXDONE
+    description: RXDONE interrupt.
+    bit_offset: 0
+    bit_size: 1
+  - name: TXDONE
+    description: Transmit Transaction completed Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+  - name: TXTRG
+    description: Transmit Trigger.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXFULL
+    description: RXFIFO full event.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXEMPTY
+    description: Transmit FIFO/Buffer Empty interrupt.
+    bit_offset: 5
+    bit_size: 1
+  - name: NACK
+    description: NACK interrupt.
+    bit_offset: 7
+    bit_size: 1
+  - name: START
+    description: START interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: STOP
+    description: STOP interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: ARBLOST
+    description: Arbitration Lost interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: PEC_RX_ERR
+    description: RX Pec Error Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIMEOUTA
+    description: TIMEOUTA interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIMEOUTB
+    description: Timeout B Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: DMA Done on Event Channel RX.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: DMA Done on Event Channel TX.
+    bit_offset: 16
+    bit_size: 1
+fieldset/CR:
+  description: Configuration.
+  fields:
+  - name: ENABLE
+    description: Enable module. After this bit has been set, it should not be set again unless it has been cleared by writing a 0 or by a reset, otherwise transfer failures may occur.
+    bit_offset: 0
+    bit_size: 1
+  - name: MCTL
+    description: MultiController mode. In MultiController mode the SCL high time counts once the SCL line has been detected high. If this is not enabled the high time counts as soon as the SCL line has been set high by the I2C controller.
+    bit_offset: 1
+    bit_size: 1
+  - name: CLKSTRETCH
+    description: Clock Stretching. This bit controls the support for clock stretching of the I2C bus.
+    bit_offset: 2
+    bit_size: 1
+fieldset/CTR:
+  description: Control Register.
+  fields:
+  - name: FRM_START
+    description: Start Transfer.
+    bit_offset: 0
+    bit_size: 1
+  - name: START
+    description: Generate START.
+    bit_offset: 1
+    bit_size: 1
+  - name: STOP
+    description: Generate STOP.
+    bit_offset: 2
+    bit_size: 1
+  - name: ACK
+    description: 'Data Acknowledge Enable. Software needs to configure this bit to send the ACK or NACK. See field decoding in Table: MCTR Field decoding.'
+    bit_offset: 3
+    bit_size: 1
+  - name: ACKOEN
+    description: ACK overrride Enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: RD_ON_TXEMPTY
+    description: Read on TX Empty.
+    bit_offset: 5
+    bit_size: 1
+  - name: SUSPEND
+    description: Suspend external communication.
+    bit_offset: 6
+    bit_size: 1
+  - name: BLEN
+    description: I2C transaction length This field contains the programmed length of bytes of the Transaction.
+    bit_offset: 16
+    bit_size: 12
+fieldset/DMA_TRIG0:
+  description: Interrupt mask.
+  fields:
+  - name: TXTRG
+    description: Transmit Trigger.
+    bit_offset: 3
+    bit_size: 1
+fieldset/DMA_TRIG1:
+  description: Interrupt mask.
+  fields:
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+fieldset/GFCTL:
+  description: I2C Glitch Filter Control.
+  fields:
+  - name: AGFEN
+    description: Analog Glitch Suppression Enable.
+    bit_offset: 8
+    bit_size: 1
+fieldset/ICLR:
+  description: Interrupt clear.
+  fields:
+  - name: RXDONE
+    description: Receive Data Interrupt Signals that a byte has been received.
+    bit_offset: 0
+    bit_size: 1
+  - name: TXDONE
+    description: Transmit Transaction completed Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+  - name: TXTRG
+    description: Transmit FIFO Trigger.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXFULL
+    description: RXFIFO full event.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXEMPTY
+    description: Transmit FIFO Empty interrupt mask. This interrupt is set if all data in the Transmit FIFO have been shifted out and the transmit goes into idle mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: NACK
+    description: Address/Data NACK Interrupt.
+    bit_offset: 7
+    bit_size: 1
+  - name: START
+    description: START Detection Interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: STOP
+    description: STOP Detection Interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: ARBLOST
+    description: Arbitration Lost Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: PEC_RX_ERR
+    description: RX Pec Error Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIMEOUTA
+    description: Timeout A interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIMEOUTB
+    description: Timeout B Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: DMA Done on Event Channel RX.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: DMA Done on Event Channel TX.
+    bit_offset: 16
+    bit_size: 1
+fieldset/IFLS:
+  description: Interrupt FIFO Level Select Register.
+  fields:
+  - name: TXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 0
+    bit_size: 3
+    enum: TXIFLSEL
+  - name: TXCLR
+    description: TX FIFO CLEAR. Setting this bit will clear the TX FIFO contents.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 4
+    bit_size: 3
+    enum: RXIFLSEL
+  - name: RXCLR
+    description: RX FIFO CLEAR. Setting this bit will clear the RX FIFO contents.
+    bit_offset: 7
+    bit_size: 1
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    description: I2C Module Interrupt Vector Value. This register provides the highes priority interrupt index. A read clears the corresponding interrupt flag in RIS and MISC. 15h-1Fh = Reserved.
+    bit_offset: 0
+    bit_size: 8
+    enum: STAT
+fieldset/INTCTL:
+  description: Interrupt control register.
+  fields:
+  - name: INTEVAL
+    description: Writing a 1 to this field re-evaluates the interrupt sources.
+    bit_offset: 0
+    bit_size: 1
+fieldset/PDBGCTL:
+  description: Peripheral Debug Control.
+  fields:
+  - name: FREE
+    description: Free run control.
+    bit_offset: 0
+    bit_size: 1
+  - name: SOFT
+    description: Soft halt boundary control. This function is only available, if [FREE] is set to 'STOP'.
+    bit_offset: 1
+    bit_size: 1
+    enum: SOFT
+fieldset/PECCTL:
+  description: I2C PEC control register.
+  fields:
+  - name: PECCNT
+    description: PEC Count When this field is non zero, the number of I2C bytes are counted (Note that although the PEC is calculated on the I2C address it is not counted at a byte). When the byte count = PECCNT and the state machine is transmitting, the contents of the LSFR is loaded into the shift register instead of the byte received from the Tx FIFO. When the state machine is receiving, after the last bit of this byte is received the LSFR is checked and if it is non-zero, a PEC RX Error interrupt is generated. The I2C packet must be padded to include the PEC byte for both transmit and receive. In transmit mode the FIFO must be loaded with a dummy PEC byte. In receive mode the PEC byte will be passed to the Rx FIFO. In the normal Controller use case, FW would set PECEN=1 and PECCNT=SMB packet length (Not including Target Address byte, but including the PEC byte). FW would then configure DMA to allow the packet to complete unassisted and write MCTR to initiate the transaction. Note that when the byte count = PEC CNT, the byte count is reset to 0 and multiple PEC calculation can automatically occur within a single I2C transaction. Note that any write to the I2PECCTL Register will clear the current PEC Byte Count in the State Machine.
+    bit_offset: 0
+    bit_size: 9
+  - name: PECEN
+    description: PEC Enable This bit enables the SMB Packet Error Checking (PEC). When enabled the PEC is calculated on all bits except the Start, Stop, Ack and Nack. The PEC LSFR and the Byte Counter is set to 0 when the State Machine is in the IDLE state, which occur following a Stop or when a timeout occurs. The Counter is also set to 0 after the PEC byte is sent or received. Note that the NACK is automatically send following a PEC byte that results in a PEC error. The PEC Polynomial is x^8 + x^2 + x^1 + 1.
+    bit_offset: 12
+    bit_size: 1
+fieldset/PECSR:
+  description: PEC status register.
+  fields:
+  - name: PECBYTECNT
+    description: PEC Byte Count. This is the current PEC Byte Count of the Controller State Machine.
+    bit_offset: 0
+    bit_size: 9
+  - name: PECSTS_CHECK
+    description: This status bit indicates if the PEC was checked in the transaction that occurred before the last Stop. Latched on Stop.
+    bit_offset: 16
+    bit_size: 1
+  - name: PECSTS_ERROR
+    description: This status bit indicates if a PEC check error occurred in the transaction that occurred before the last Stop. Latched on Stop.
+    bit_offset: 17
+    bit_size: 1
+fieldset/RXDATA:
+  description: RXData.
+  fields:
+  - name: DATA
+    description: Received Data. This field contains the last received data.
+    bit_offset: 0
+    bit_size: 8
+fieldset/SR:
+  description: Status Register.
+  fields:
+  - name: BUSY
+    description: FSM Busy The BUSY bit is set during an ongoing transaction, so is set during the transmit/receive of the amount of data set in MBLEN including START, RESTART, Address and STOP signal generation when required for the current transaction.
+    bit_offset: 0
+    bit_size: 1
+  - name: ERR
+    description: Error The error can be from the Target address not being acknowledged or the transmit data not being acknowledged.
+    bit_offset: 1
+    bit_size: 1
+  - name: ADRACK
+    description: Acknowledge Address.
+    bit_offset: 2
+    bit_size: 1
+  - name: DATACK
+    description: Acknowledge Data.
+    bit_offset: 3
+    bit_size: 1
+  - name: ARBLST
+    description: Arbitration Lost.
+    bit_offset: 4
+    bit_size: 1
+  - name: IDLE
+    description: I2C Idle.
+    bit_offset: 5
+    bit_size: 1
+  - name: BUSBSY
+    description: I2C Bus is Busy Controller State Machine will wait until this bit to be cleared before starting a transaction. When first enabling the Controller in multi Controller environments, FW should wait for one I2C clock period after setting ACTIVE high before writing to the CTR register to start the transaction so that if SCL goes low it will trigger the BUSBSY.
+    bit_offset: 6
+    bit_size: 1
+  - name: RXCLR
+    description: RX FIFO Clear Status.
+    bit_offset: 9
+    bit_size: 1
+  - name: TXCLR
+    description: TX FIFO Clear Status.
+    bit_offset: 10
+    bit_size: 1
+  - name: RXFE
+    description: Receive FIFO Empty The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 11
+    bit_size: 1
+  - name: RXFF
+    description: Receive FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 12
+    bit_size: 1
+  - name: TXFE
+    description: Transmit FIFO Empty The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 13
+    bit_size: 1
+  - name: TXFF
+    description: Transmit FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 14
+    bit_size: 1
+  - name: BCNT
+    description: Transaction Count This field contains the current count-down value of the transaction.
+    bit_offset: 16
+    bit_size: 12
+fieldset/TA:
+  description: Target Address Register.
+  fields:
+  - name: DIR
+    description: Receive/Send The DIR bit specifies if the next operation is a Receive (High) or Transmit (Low). 0h = Transmit 1h = Receive.
+    bit_offset: 0
+    bit_size: 1
+    enum: DIR
+  - name: ADDR
+    description: I2C Target Address This field specifies bits A9 through A0 of the Target address. In 7-bit addressing mode as selected by MSA.MODE bit, the top 3 bits are don't care.
+    bit_offset: 1
+    bit_size: 10
+  - name: MODE
+    description: This bit selects the adressing mode to be used When 0, 7-bit addressing is used. When 1, 10-bit addressing is used.
+    bit_offset: 15
+    bit_size: 1
+    enum: MODE
+fieldset/TIMEOUT_CNT:
+  description: I2C Timeout Count Register.
+  fields:
+  - name: TCNTA
+    description: 'Timeout Count A Current Count: This field contains the upper 8 bits of a 12-bit current counter for timeout counter A.'
+    bit_offset: 0
+    bit_size: 8
+  - name: TCNTB
+    description: 'Timeout Count B Current Count: This field contains the upper 8 bits of a 12-bit current counter for timeout counter B.'
+    bit_offset: 16
+    bit_size: 8
+fieldset/TIMEOUT_CTL:
+  description: I2C Timeout Count Control Register.
+  fields:
+  - name: TCNTLA
+    description: 'Timeout counter A load value Counter A is used for SCL low detection. This field contains the upper 8 bits of a 12-bit pre-load value for the Timeout A count. NOTE: The value of CNTLA must be greater than 1h. Each count is equal to 520 times the timeout period of functional clock. For example, with 8MHz functional clock and a 100KHz operating I2C clock, one timeout period will be equal to (1 / 8MHz) * 520 or 65 us.'
+    bit_offset: 0
+    bit_size: 8
+  - name: TCNTAEN
+    description: Timeout Counter A Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: TCNTLB
+    description: 'Timeout Count B Load: Counter B is used for SCL High Detection. This field contains the upper 8 bits of a 12-bit pre-load value for the Timeout B count. NOTE: The value of CNTLB must be greater than 1h. Each count is equal to 1* clock period. For example, with 10MHz functional clock one timeout period will be equal to1*100ns.'
+    bit_offset: 16
+    bit_size: 8
+  - name: TCNTBEN
+    description: Timeout Counter B Enable.
+    bit_offset: 31
+    bit_size: 1
+fieldset/TPR:
+  description: Timer Period.
+  fields:
+  - name: TPR
+    description: 'Timer Period This field is used in the equation to configure SCL_PERIOD : SCL_PERIOD = (1 + TPR ) * (SCL_LP + SCL_HP ) * INT_CLK_PRD where: SCL_PRD is the SCL line period (I2C clock). TPR is the Timer Period register value (range of 1 to 127). SCL_LP is the SCL Low period (fixed at 6). SCL_HP is the SCL High period (fixed at 4). CLK_PRD is the functional clock period in ns.'
+    bit_offset: 0
+    bit_size: 7
+fieldset/TXDATA:
+  description: TXData.
+  fields:
+  - name: DATA
+    description: Transmit Data This byte contains the data to be transferred during the next transaction.
+    bit_offset: 0
+    bit_size: 8
+enum/DIR:
+  bit_size: 1
+  variants:
+  - name: TRANSMIT
+    description: in transmit mode.
+    value: 0
+  - name: RECEIVE
+    description: is in receive mode.
+    value: 1
+enum/MODE:
+  bit_size: 1
+  variants:
+  - name: MODE7
+    description: 7-bit addressing mode.
+    value: 0
+  - name: MODE10
+    description: 10-bit addressing mode.
+    value: 1
+enum/RXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_1_4
+    description: RX FIFO >= 1/4 full.
+    value: 1
+  - name: LVL_1_2
+    description: RX FIFO >= 1/2 full (default).
+    value: 2
+  - name: LVL_3_4
+    description: RX FIFO >= 3/4 full.
+    value: 3
+  - name: LVL_NOT_EMPTY
+    description: Opposite of empty.
+    value: 4
+  - name: LVL_FULL
+    description: RX FIFO is full.
+    value: 5
+  - name: LVL_ALMOST_FULL
+    description: RX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 6
+  - name: LVL_ALMOST_EMPTY
+    description: RX_FIFO <= 1.
+    value: 7
+enum/SOFT:
+  bit_size: 1
+  variants:
+  - name: DEPRECATED
+    description: Not supported.
+    value: 0
+  - name: DELAYED
+    description: The peripheral blocks the debug freeze until it has reached a boundary where it can resume without corruption.
+    value: 1
+enum/STAT:
+  bit_size: 8
+  variants:
+  - name: NO_INTR
+    description: No interrupt pending.
+    value: 0
+  - name: RXDONEFG
+    description: Data received.
+    value: 1
+  - name: TXDONEFG
+    description: data transmitted.
+    value: 2
+  - name: RXTRG
+    description: Receive Trigger.
+    value: 3
+  - name: TXTRG
+    description: Transmit Trigger.
+    value: 4
+  - name: RXFULL
+    description: RX FIFO FULL Event/interrupt pending.
+    value: 5
+  - name: TXEMPTY
+    description: Transmit FIFO/Buffer Empty Event/interrupt pending.
+    value: 6
+  - name: NACKFG
+    description: Address/Data NACK.
+    value: 8
+  - name: STARTFG
+    description: Start Event.
+    value: 9
+  - name: STOPFG
+    description: Stop Event.
+    value: 10
+  - name: ARBLOSTFG
+    description: Arbitration Lost.
+    value: 11
+  - name: PEC_RX_ERR
+    description: PEC Receive Error Event.
+    value: 12
+  - name: TIMEOUTA
+    description: Timeout A Event.
+    value: 13
+  - name: TIMEOUTB
+    description: Timeout B Event.
+    value: 14
+  - name: DMA_DONE_RX
+    description: DMA DONE on Channel RX.
+    value: 16
+  - name: DMA_DONE_TX
+    description: DMA DONE on Channel TX.
+    value: 17
+  - name: DMA_PREIRQ_RX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 19
+  - name: DMA_PREIRQ_TX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 20
+enum/TXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_3_4
+    description: TX FIFO <= 3/4 empty.
+    value: 1
+  - name: LVL_1_2
+    description: TX FIFO <= 1/2 empty (default).
+    value: 2
+  - name: LVL_1_4
+    description: TX FIFO <= 1/4 empty.
+    value: 3
+  - name: LVL_NOT_FULL
+    description: Opposite of full.
+    value: 4
+  - name: LVL_EMPTY
+    description: TX FIFO is empty.
+    value: 5
+  - name: LVL_ALMOST_EMPTY
+    description: TX FIFO <= 1.
+    value: 6
+  - name: LVL_ALMOST_FULL
+    description: TX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 7

--- a/data/registers/unicommi2ct_v1.yaml
+++ b/data/registers/unicommi2ct_v1.yaml
@@ -1,0 +1,772 @@
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: CPU_INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: CPU_INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: CPU_INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: CPU_INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: ICLR
+block/DMA_TRIG0:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG0
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG0
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG0
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG0
+block/DMA_TRIG1:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG1
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG1
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG1
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG1
+block/UNICOMMI2CT:
+  description: PERIPHERALREGION.
+  items:
+  - name: CLKDIV
+    description: Clock Divider.
+    byte_offset: 4096
+    fieldset: CLKDIV
+  - name: CLKSEL
+    description: Clock Select for Ultra Low Power peripherals.
+    byte_offset: 4104
+    fieldset: CLKSEL
+  - name: PDBGCTL
+    description: Peripheral Debug Control.
+    byte_offset: 4120
+    fieldset: PDBGCTL
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: DMA_TRIG1
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4176
+    block: DMA_TRIG1
+  - name: DMA_TRIG0
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4224
+    block: DMA_TRIG0
+  - name: INTCTL
+    description: Interrupt control register.
+    byte_offset: 4324
+    access: Write
+    fieldset: INTCTL
+  - name: CTR
+    description: I2C Target Control Register.
+    byte_offset: 4352
+    fieldset: CTR
+  - name: ACKCTL
+    description: I2C Target ACK Control.
+    byte_offset: 4356
+    fieldset: ACKCTL
+  - name: SR
+    description: Status Register.
+    byte_offset: 4360
+    access: Read
+    fieldset: SR
+  - name: IFLS
+    description: Interrupt FIFO Level Select Register.
+    byte_offset: 4364
+    fieldset: IFLS
+  - name: GFCTL
+    description: I2C Glitch Filter Control.
+    byte_offset: 4376
+    fieldset: GFCTL
+  - name: TTXDATA
+    description: I2C TXData.
+    byte_offset: 4384
+    access: Write
+    fieldset: TTXDATA
+  - name: RXDATA
+    description: I2C RXData.
+    byte_offset: 4388
+    access: Read
+    fieldset: RXDATA
+  - name: PECSR
+    description: PEC status register.
+    byte_offset: 4392
+    access: Read
+    fieldset: PECSR
+  - name: OAR2
+    description: Own Address 2.
+    byte_offset: 4424
+    fieldset: OAR2
+  - name: OAR
+    description: I2C Own Address.
+    byte_offset: 4428
+    fieldset: OAR
+  - name: TIMEOUT_CNT
+    description: I2C Timeout Count Register.
+    byte_offset: 4432
+    access: Read
+    fieldset: TIMEOUT_CNT
+  - name: TIMEOUT_CTL
+    description: I2C Timeout Count Control Register.
+    byte_offset: 4436
+    fieldset: TIMEOUT_CTL
+  - name: PECCTL
+    description: I2C PEC control register.
+    byte_offset: 4440
+    fieldset: PECCTL
+fieldset/ACKCTL:
+  description: I2C Target ACK Control.
+  fields:
+  - name: ACKOEN
+    description: I2C Target ACK Override Enable Read SR.ACKOEN to check current status of this bit.
+    bit_offset: 0
+    bit_size: 1
+  - name: ACKOVAL
+    description: 'ACK Override Value Note: for General Call this bit will be ignored if set to NACK and Target continues to receive data.'
+    bit_offset: 1
+    bit_size: 1
+  - name: ACKOEN_ON_START
+    description: When set this bit will automatically enable target override acknowlede following a Start Condition. Status bit ACKOEN will reflect a value of '1' when automatic override enable is used.
+    bit_offset: 2
+    bit_size: 1
+  - name: ACKOEN_ON_PECNEXT
+    description: When set this bit will automatically turn on the Target acknowledge override following a ACK/NACK of the byte received just prior to the PEC byte. However, setting ACKCTL.ACKOEN bit will not automatically be ACKed/NACKed by the State Machine and firmware must perform this function by writing Target.ACKCTL register. Status bit ACKOEN will reflect a value of '1' when automatic override enable is used.
+    bit_offset: 3
+    bit_size: 1
+  - name: ACKOEN_ON_PECDONE
+    description: When set, this bit will automatically turn on target acknowledge enable field following the ACK/NACK of the received PEC byte. Status bit ACKOEN will reflect a value of '1' when automatic override enable is used.
+    bit_offset: 4
+    bit_size: 1
+fieldset/CLKDIV:
+  description: Clock Divider.
+  fields:
+  - name: RATIO
+    description: 'Divide ratio of the module clock, as the divisor minus one: 0 divides by 1 and 63 by 64.'
+    bit_offset: 0
+    bit_size: 6
+fieldset/CLKSEL:
+  description: Clock Select for Ultra Low Power peripherals.
+  fields:
+  - name: MFCLK_SEL
+    description: Selects MFCLK as clock source if enabled.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSCLK_SEL
+    description: Selects BUS CLK as clock source if enabled.
+    bit_offset: 3
+    bit_size: 1
+fieldset/CPU_INT:
+  description: Interrupt mask.
+  fields:
+  - name: RXDONE
+    description: Receive Data Interrupt Signals that a byte has been received.
+    bit_offset: 0
+    bit_size: 1
+  - name: TXDONE
+    description: Transmit Transaction completed Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+  - name: TXTRG
+    description: Transmit Trigger.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXFULL
+    description: RXFIFO full event. This interrupt is set if an Target RX FIFO is full.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXEMPTY
+    description: Target Transmit FIFO Empty interrupt mask. This interrupt is set if all data in the Transmit FIFO have been shifted out and the transmit goes into idle mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: TX_UNFL
+    description: Target TX FIFO underflow.
+    bit_offset: 6
+    bit_size: 1
+  - name: RX_OVFL
+    description: Target RX FIFO overflow.
+    bit_offset: 7
+    bit_size: 1
+  - name: GENCALL
+    description: General Call Interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: START
+    description: Start Condition Interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: STOP
+    description: Stop Condition Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: PEC_RX_ERR
+    description: RX Pec Error Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIMEOUTA
+    description: Timeout A Interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIMEOUTB
+    description: Timeout B Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: DMA Done on Event Channel RX.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: DMA Done on Event Channel TX.
+    bit_offset: 16
+    bit_size: 1
+  - name: ARBLOST
+    description: Arbitration Lost Interrupt.
+    bit_offset: 17
+    bit_size: 1
+fieldset/CTR:
+  description: I2C Target Control Register.
+  fields:
+  - name: ENABLE
+    description: Setting this bit enables the module.
+    bit_offset: 0
+    bit_size: 1
+  - name: GENCALL
+    description: General call response enable Modify only when UCSWRST = 1. 0b = Do not respond to a general call 1b = Respond to a general call.
+    bit_offset: 1
+    bit_size: 1
+  - name: TXEMPTY_ON_TREQ
+    description: Tx Empty Interrupt on TREQ.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXTRIG_TXMODE
+    description: Tx Trigger when Target FSM is in Tx Mode.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXWAIT_STALE_TXFIFO
+    description: 'Tx transfer waits when stale data in Tx FIFO. This prevents stale bytes left in the TX FIFO from automatically being sent on the next I2C packet. Note: this should be used with TXEMPTY_ON_TREQ set to prevent the Target State Machine from waiting for TX FIFO data without an interrupt notification when the FIFO data is stale.'
+    bit_offset: 5
+    bit_size: 1
+  - name: RXFULL_ON_RREQ
+    description: Rx full interrupt generated on RREQ condition as indicated in SSR.
+    bit_offset: 6
+    bit_size: 1
+  - name: EN_DEFHOSTADR
+    description: Enable Default Host Address.
+    bit_offset: 7
+    bit_size: 1
+  - name: EN_ALRESPADR
+    description: Enable Alert Response Address.
+    bit_offset: 8
+    bit_size: 1
+  - name: EN_DEFDEVADR
+    description: Enable Default device address.
+    bit_offset: 9
+    bit_size: 1
+  - name: SUSPEND
+    description: Suspend external communication.
+    bit_offset: 11
+    bit_size: 1
+  - name: CLKSTRETCH
+    description: Clock Stretch Enable.
+    bit_offset: 20
+    bit_size: 1
+  - name: WUEN
+    description: Target Wakeup Enable.
+    bit_offset: 21
+    bit_size: 1
+fieldset/DMA_TRIG0:
+  description: Interrupt mask.
+  fields:
+  - name: TXTRG
+    description: Transmit Trigger.
+    bit_offset: 3
+    bit_size: 1
+fieldset/DMA_TRIG1:
+  description: Interrupt mask.
+  fields:
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+fieldset/GFCTL:
+  description: I2C Glitch Filter Control.
+  fields:
+  - name: AGFEN
+    description: Analog Glitch Suppression Enable.
+    bit_offset: 8
+    bit_size: 1
+fieldset/ICLR:
+  description: Interrupt clear.
+  fields:
+  - name: RXDONE
+    description: Target Receive Data Interrupt Signals that a byte has been received.
+    bit_offset: 0
+    bit_size: 1
+  - name: TXDONE
+    description: Target Transmit Transaction completed Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXTRG
+    description: Receive Trigger.
+    bit_offset: 2
+    bit_size: 1
+  - name: TXTRG
+    description: Transmit Trigger.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXFULL
+    description: RXFIFO full event. This interrupt is set if an RX FIFO is full.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXEMPTY
+    description: Transmit FIFO Empty interrupt mask. This interrupt is set if all data in the Transmit FIFO have been shifted out and the transmit goes into idle mode.
+    bit_offset: 5
+    bit_size: 1
+  - name: TX_UNFL
+    description: Target TX FIFO underflow.
+    bit_offset: 6
+    bit_size: 1
+  - name: RX_OVFL
+    description: Target RX FIFO overflow.
+    bit_offset: 7
+    bit_size: 1
+  - name: GENCALL
+    description: General Call Interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: START
+    description: Target START Detection Interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: STOP
+    description: Target STOP Detection Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: PEC_RX_ERR
+    description: Target RX Pec Error Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: TIMEOUTA
+    description: Timeout A interrupt.
+    bit_offset: 12
+    bit_size: 1
+  - name: TIMEOUTB
+    description: Timeout B Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: DMA Done on Event Channel RX.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: DMA Done on Event Channel TX.
+    bit_offset: 16
+    bit_size: 1
+  - name: ARBLOST
+    description: Arbitration Lost Interrupt.
+    bit_offset: 17
+    bit_size: 1
+fieldset/IFLS:
+  description: Interrupt FIFO Level Select Register.
+  fields:
+  - name: TXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 0
+    bit_size: 3
+    enum: TXIFLSEL
+  - name: TXCLR
+    description: TX FIFO CLEAR. Setting this bit will clear the TX FIFO contents.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 4
+    bit_size: 3
+    enum: RXIFLSEL
+  - name: RXCLR
+    description: RX FIFO CLEAR. Setting this bit will clear the RX FIFO contents.
+    bit_offset: 7
+    bit_size: 1
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    description: I2C Module Interrupt Vector Value. This register provides the highes priority interrupt index. A read clears the corresponding interrupt flag in RIS and MISC. 15h-1Fh = Reserved.
+    bit_offset: 0
+    bit_size: 8
+    enum: STAT
+fieldset/INTCTL:
+  description: Interrupt control register.
+  fields:
+  - name: INTEVAL
+    description: Writing a 1 to this field re-evaluates the interrupt sources.
+    bit_offset: 0
+    bit_size: 1
+fieldset/OAR:
+  description: I2C Own Address.
+  fields:
+  - name: OAR
+    description: 'Own Address: This field specifies bits A9 through A0 of the Target address. In 7-bit addressing mode as selected by I2CSOAR.MODE bit, the top 3 bits are don''t care.'
+    bit_offset: 0
+    bit_size: 10
+  - name: OAREN
+    description: Own Address Enable.
+    bit_offset: 14
+    bit_size: 1
+  - name: MODE
+    description: This bit selects the adressing mode to be used. When 0, 7-bit addressing is used. When 1, 10-bit addressing is used.
+    bit_offset: 15
+    bit_size: 1
+    enum: MODE
+fieldset/OAR2:
+  description: Own Address 2.
+  fields:
+  - name: OAR2
+    description: Own Address 2This field specifies the alternate OAR2 address.
+    bit_offset: 0
+    bit_size: 7
+  - name: OAR2EN
+    description: Own Address 2 Enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: OAR2_MASK
+    description: 'Own Address 2 Mask: This field specifies bits A6 through A0 of the Target address. The bits with value 1 in SOAR2.OAR2_MASK field will make the corresponding incoming address bits to match by default regardless of the value inside SOAR2.OAR2 i.e. corresponding SOAR2.OAR2 bit is a dont care.'
+    bit_offset: 16
+    bit_size: 7
+fieldset/PDBGCTL:
+  description: Peripheral Debug Control.
+  fields:
+  - name: FREE
+    description: Free run control.
+    bit_offset: 0
+    bit_size: 1
+  - name: SOFT
+    description: Soft halt boundary control. This function is only available, if [FREE] is set to 'STOP'.
+    bit_offset: 1
+    bit_size: 1
+    enum: SOFT
+fieldset/PECCTL:
+  description: I2C PEC control register.
+  fields:
+  - name: PECCNT
+    description: When this field is non zero, the number of I2C data bytes are counted. When the byte count = PECCNT and the state machine is transmitting, the contents of the LSFR is loaded into the shift register instead of the byte received from the Tx FIFO. When the state machine is receiving, after the last bit of this byte is received the LSFR is checked and if it is non-zero, a PEC RX Error interrupt is generated. The I2C packet must be padded to include the PEC byte for both transmit and receive. In transmit mode the FIFO must be loaded with a dummy PEC byte. In receive mode the PEC byte will be passed to the Rx FIFO. In the normal use case, FW would set PECEN=1 and PECCNT=0 and use the ACKOEN until the remaining SMB packet length is known. FW would then set the PECCNT to the remaining packet length (Including PEC bye). FW would then configure DMA to allow the packet to complete unassisted and exit NoAck mode. Note that when the byte count = PEC CNT, the byte count is reset to 0 and multiple PEC calculation can automatically occur within a single I2C transaction.
+    bit_offset: 0
+    bit_size: 9
+  - name: PECEN
+    description: PEC Enable This bit enables the SMB Packet Error Checking (PEC). When enabled the PEC is calculated on all bits except the Start, Stop, Ack and Nack. The PEC LSFR and the Byte Counter is set to 0 when the State Machine is in the IDLE state, which occur following a Stop or when a timeout occurs. The Counter is also set to 0 after the PEC byte is sent or received. Note that the NACK is automatically send following a PEC byte that results in a PEC error. The PEC Polynomial is x^8 + x^2 + x^1 + 1.
+    bit_offset: 12
+    bit_size: 1
+fieldset/PECSR:
+  description: PEC status register.
+  fields:
+  - name: PECBYTECNT
+    description: This is the current PEC Byte Count of the State Machine.
+    bit_offset: 0
+    bit_size: 9
+  - name: PECSTS_CHECK
+    description: This status bit indicates if the PEC was checked in the transaction that occurred before the last Stop. Latched on Stop.
+    bit_offset: 16
+    bit_size: 1
+  - name: PECSTS_ERROR
+    description: This status bit indicates if a PEC check error occurred in the transaction that occurred before the last Stop. Latched on Stop.
+    bit_offset: 17
+    bit_size: 1
+fieldset/RXDATA:
+  description: I2C RXData.
+  fields:
+  - name: DATA
+    description: Received Data. This field contains the last received data.
+    bit_offset: 0
+    bit_size: 8
+fieldset/SR:
+  description: Status Register.
+  fields:
+  - name: RREQ
+    description: Receive Request.
+    bit_offset: 0
+    bit_size: 1
+  - name: TREQ
+    description: Transmit Request.
+    bit_offset: 1
+    bit_size: 1
+  - name: RXMODE
+    description: Target FSM is in Rx MODE.
+    bit_offset: 2
+    bit_size: 1
+  - name: OAR2SEL
+    description: OAR2 Address Matched This bit gets reevaluated after every address comparison.
+    bit_offset: 3
+    bit_size: 1
+  - name: QCMDST
+    description: 'Quick Command Status Value Description: 0: The last transaction was a normal transaction or a transaction has not occurred. 1: The last transaction was a Quick Command transaction.'
+    bit_offset: 4
+    bit_size: 1
+  - name: QCMDRW
+    description: 'Quick Command Read / Write This bit only has meaning when the QCMDST bit is set. Value Description: 0: Quick command was a write 1: Quick command was a read.'
+    bit_offset: 5
+    bit_size: 1
+  - name: BUSBSY
+    description: I2C bus is busy.
+    bit_offset: 6
+    bit_size: 1
+  - name: TXMODE
+    description: FSM is in TX MODE.
+    bit_offset: 7
+    bit_size: 1
+  - name: STALE_TXFIFO
+    description: Stale Tx FIFO.
+    bit_offset: 8
+    bit_size: 1
+  - name: RXCLR
+    description: RX FIFO Clear Status.
+    bit_offset: 9
+    bit_size: 1
+  - name: TXCLR
+    description: TX FIFO Clear Status.
+    bit_offset: 10
+    bit_size: 1
+  - name: RXFE
+    description: Receive FIFO Empty The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 11
+    bit_size: 1
+  - name: RXFF
+    description: Receive FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 12
+    bit_size: 1
+  - name: TXFE
+    description: Transmit FIFO Empty The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 13
+    bit_size: 1
+  - name: TXFF
+    description: Transmit FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 14
+    bit_size: 1
+  - name: ACKOEN
+    description: Status of ACK Override Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: ADDRMATCH
+    description: Indicates the address for which Target address match happened.
+    bit_offset: 16
+    bit_size: 10
+fieldset/TIMEOUT_CNT:
+  description: I2C Timeout Count Register.
+  fields:
+  - name: TCNTA
+    description: 'Timeout Count A Current Count: This field contains the upper 8 bits of a 12-bit current counter for timeout counter A.'
+    bit_offset: 0
+    bit_size: 8
+  - name: TCNTB
+    description: 'Timeout Count B Current Count: This field contains the upper 8 bits of a 12-bit current counter for timeout counter B.'
+    bit_offset: 16
+    bit_size: 8
+fieldset/TIMEOUT_CTL:
+  description: I2C Timeout Count Control Register.
+  fields:
+  - name: TCNTLA
+    description: 'Timeout counter A load value Counter A is used for SCL low detection. This field contains the upper 8 bits of a 12-bit pre-load value for the Timeout A count. NOTE: The value of CNTLA must be greater than 1h. Each count is equal to 520 times the timeout period of functional clock. For example, with 8MHz functional clock and a 100KHz operating I2C clock, one timeout period will be equal to (1 / 8MHz) * 520 or 65 us.'
+    bit_offset: 0
+    bit_size: 8
+  - name: TCNTAEN
+    description: Timeout Counter A Enable.
+    bit_offset: 15
+    bit_size: 1
+  - name: TCNTLB
+    description: 'Timeout Count B Load: Counter B is used for SCL High Detection. This field contains the upper 8 bits of a 12-bit pre-load value for the Timeout B count. NOTE: The value of CNTLB must be greater than 1h. Each count is equal to 1* clock period. For example, with 10MHz functional clock one timeout period will be equal to1*100ns.'
+    bit_offset: 16
+    bit_size: 8
+  - name: TCNTBEN
+    description: Timeout Counter B Enable.
+    bit_offset: 31
+    bit_size: 1
+fieldset/TTXDATA:
+  description: I2C TXData.
+  fields:
+  - name: DATA
+    description: Transmit Data This byte contains the data to be transferred during the next transaction.
+    bit_offset: 0
+    bit_size: 8
+enum/MODE:
+  bit_size: 1
+  variants:
+  - name: MODE7
+    description: Enable 7-bit addressing.
+    value: 0
+  - name: MODE10
+    description: Enable 10-bit addressing.
+    value: 1
+enum/RXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_1_4
+    description: RX FIFO >= 1/4 full.
+    value: 1
+  - name: LVL_1_2
+    description: RX FIFO >= 1/2 full (default).
+    value: 2
+  - name: LVL_3_4
+    description: RX FIFO >= 3/4 full.
+    value: 3
+  - name: LVL_NOT_EMPTY
+    description: Opposite of empty.
+    value: 4
+  - name: LVL_FULL
+    description: RX FIFO is full.
+    value: 5
+  - name: LVL_ALMOST_FULL
+    description: RX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 6
+  - name: LVL_ALMOST_EMPTY
+    description: RX_FIFO <= 1.
+    value: 7
+enum/SOFT:
+  bit_size: 1
+  variants:
+  - name: DEPRECATED
+    description: Not supported.
+    value: 0
+  - name: DELAYED
+    description: The peripheral blocks the debug freeze until it has reached a boundary where it can resume without corruption.
+    value: 1
+enum/STAT:
+  bit_size: 8
+  variants:
+  - name: NO_INTR
+    description: No interrupt pending.
+    value: 0
+  - name: RXDONEFG
+    description: Receive Done Flag.
+    value: 1
+  - name: TXDONEFG
+    description: Transmit Done Flag.
+    value: 2
+  - name: RXTRG
+    description: receive FIFO Trigger Level.
+    value: 3
+  - name: TXTRG
+    description: transmit FIFO Trigger level.
+    value: 4
+  - name: RXFULL
+    description: RX FIFO FULL Event/interrupt pending.
+    value: 5
+  - name: TXEMPTY
+    description: Transmit FIFO/Buffer Empty Event/interrupt pending.
+    value: 6
+  - name: TX_UNFL
+    description: Target TX FIFO underflow.
+    value: 7
+  - name: RX_OVFL
+    description: Target RX FIFO overflow event.
+    value: 8
+  - name: GENCALL
+    description: General Call Event.
+    value: 9
+  - name: STARTFG
+    description: Start Event.
+    value: 10
+  - name: STOPFG
+    description: Stop Event.
+    value: 11
+  - name: PEC_RX_ERR
+    description: PEC receive error event.
+    value: 12
+  - name: TIMEOUTA
+    description: Timeout A Event.
+    value: 13
+  - name: TIMEOUTB
+    description: Timeout B Event.
+    value: 14
+  - name: DMA_DONE_RX
+    description: DMA DONE on Channel RX.
+    value: 16
+  - name: DMA_DONE_TX
+    description: DMA DONE on Channel TX.
+    value: 17
+  - name: ARBLOSTFG
+    description: Arbitration Lost.
+    value: 18
+  - name: DMA_PREIRQ_RX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 19
+  - name: DMA_PREIRQ_TX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 20
+enum/TXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_3_4
+    description: TX FIFO <= 3/4 empty.
+    value: 1
+  - name: LVL_1_2
+    description: TX FIFO <= 1/2 empty (default).
+    value: 2
+  - name: LVL_1_4
+    description: TX FIFO <= 1/4 empty.
+    value: 3
+  - name: LVL_NOT_FULL
+    description: Opposite of full.
+    value: 4
+  - name: LVL_EMPTY
+    description: TX FIFO is empty.
+    value: 5
+  - name: LVL_ALMOST_EMPTY
+    description: TX FIFO <= 1.
+    value: 6
+  - name: LVL_ALMOST_FULL
+    description: TX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 7

--- a/data/registers/unicommi2ct_v1.yaml
+++ b/data/registers/unicommi2ct_v1.yaml
@@ -28,7 +28,7 @@ block/CPU_INT:
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: ICLR
+    fieldset: CPU_INT
 block/DMA_TRIG0:
   items:
   - name: IMASK
@@ -349,77 +349,6 @@ fieldset/GFCTL:
   - name: AGFEN
     description: Analog Glitch Suppression Enable.
     bit_offset: 8
-    bit_size: 1
-fieldset/ICLR:
-  description: Interrupt clear.
-  fields:
-  - name: RXDONE
-    description: Target Receive Data Interrupt Signals that a byte has been received.
-    bit_offset: 0
-    bit_size: 1
-  - name: TXDONE
-    description: Target Transmit Transaction completed Interrupt.
-    bit_offset: 1
-    bit_size: 1
-  - name: RXTRG
-    description: Receive Trigger.
-    bit_offset: 2
-    bit_size: 1
-  - name: TXTRG
-    description: Transmit Trigger.
-    bit_offset: 3
-    bit_size: 1
-  - name: RXFULL
-    description: RXFIFO full event. This interrupt is set if an RX FIFO is full.
-    bit_offset: 4
-    bit_size: 1
-  - name: TXEMPTY
-    description: Transmit FIFO Empty interrupt mask. This interrupt is set if all data in the Transmit FIFO have been shifted out and the transmit goes into idle mode.
-    bit_offset: 5
-    bit_size: 1
-  - name: TX_UNFL
-    description: Target TX FIFO underflow.
-    bit_offset: 6
-    bit_size: 1
-  - name: RX_OVFL
-    description: Target RX FIFO overflow.
-    bit_offset: 7
-    bit_size: 1
-  - name: GENCALL
-    description: General Call Interrupt.
-    bit_offset: 8
-    bit_size: 1
-  - name: START
-    description: Target START Detection Interrupt.
-    bit_offset: 9
-    bit_size: 1
-  - name: STOP
-    description: Target STOP Detection Interrupt.
-    bit_offset: 10
-    bit_size: 1
-  - name: PEC_RX_ERR
-    description: Target RX Pec Error Interrupt.
-    bit_offset: 11
-    bit_size: 1
-  - name: TIMEOUTA
-    description: Timeout A interrupt.
-    bit_offset: 12
-    bit_size: 1
-  - name: TIMEOUTB
-    description: Timeout B Interrupt.
-    bit_offset: 13
-    bit_size: 1
-  - name: DMA_DONE_RX
-    description: DMA Done on Event Channel RX.
-    bit_offset: 15
-    bit_size: 1
-  - name: DMA_DONE_TX
-    description: DMA Done on Event Channel TX.
-    bit_offset: 16
-    bit_size: 1
-  - name: ARBLOST
-    description: Arbitration Lost Interrupt.
-    bit_offset: 17
     bit_size: 1
 fieldset/IFLS:
   description: Interrupt FIFO Level Select Register.

--- a/data/registers/unicommspi_v1.yaml
+++ b/data/registers/unicommspi_v1.yaml
@@ -1,0 +1,726 @@
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt Index Register.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: CPU_INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: CPU_INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: CPU_INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: CPU_INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: ICLR
+block/DMA_TRIG_RX:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG_RX
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG_RX
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG_RX
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG_RX
+block/DMA_TRIG_TX:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG_TX
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG_TX
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG_TX
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG_TX
+block/UNICOMMSPI:
+  description: PERIPHERALREGION.
+  items:
+  - name: CLKDIV
+    description: Clock Divider.
+    byte_offset: 4096
+    fieldset: CLKDIV
+  - name: CLKSEL
+    description: Clock Select for Ultra Low Power peripherals.
+    byte_offset: 4104
+    fieldset: CLKSEL
+  - name: PDBGCTL
+    description: Peripheral Debug Control.
+    byte_offset: 4120
+    fieldset: PDBGCTL
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: DMA_TRIG_RX
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4176
+    block: DMA_TRIG_RX
+  - name: DMA_TRIG_TX
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4224
+    block: DMA_TRIG_TX
+  - name: INTCTL
+    description: Interrupt control register.
+    byte_offset: 4324
+    access: Write
+    fieldset: INTCTL
+  - name: CTL0
+    description: SPI control register 0.
+    byte_offset: 4352
+    fieldset: CTL0
+  - name: STAT
+    description: Status Register.
+    byte_offset: 4360
+    access: Read
+    fieldset: STAT
+  - name: IFLS
+    description: Interrupt FIFO Level Select Register.
+    byte_offset: 4364
+    fieldset: IFLS
+  - name: CLKCTL
+    description: Clock prescaler and divider register.
+    byte_offset: 4368
+    fieldset: CLKCTL
+  - name: TXDATA
+    description: TXDATA Register.
+    byte_offset: 4384
+    access: Write
+    fieldset: TXDATA
+  - name: RXDATA
+    description: RXDATA Register.
+    byte_offset: 4388
+    access: Read
+    fieldset: RXDATA
+  - name: CTL1
+    description: SPI control register 1.
+    byte_offset: 4428
+    fieldset: CTL1
+fieldset/CLKCTL:
+  description: Clock prescaler and divider register.
+  fields:
+  - name: SCR
+    description: 'Serial clock divider: This is used to generate the transmit and receive bit rate of the SPI. The SPI bit rate is (SPI''s functional clock frequency)/((SCR+1)*2). SCR is a value from 0-1023.'
+    bit_offset: 0
+    bit_size: 10
+  - name: DSAMPLE
+    description: 'Delayed sampling value. In controller mode the data on the input pin will be delayed sampled by the defined clock cycles of internal functional clock hence relaxing the setup time of input data. This setting is useful in systems where the board delays and external peripheral delays are more than the input setup time of the controller. Please refer to the datasheet for values of controller input setup time and assess what DSAMPLE value meets the requirement of the system. Note: High values of DSAMPLE can cause HOLD time violations and must be factored in the calculations.'
+    bit_offset: 28
+    bit_size: 4
+fieldset/CLKDIV:
+  description: Clock Divider.
+  fields:
+  - name: RATIO
+    description: Selects divide ratio of module clock.
+    bit_offset: 0
+    bit_size: 3
+    enum: RATIO
+fieldset/CLKSEL:
+  description: Clock Select for Ultra Low Power peripherals.
+  fields:
+  - name: LFCLK_SEL
+    description: Selects LFCLK as clock source if enabled.
+    bit_offset: 1
+    bit_size: 1
+  - name: MFCLK_SEL
+    description: Selects MFCLK as clock source if enabled.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSCLK_SEL
+    description: Selects buscclk as clock source if enabled.
+    bit_offset: 3
+    bit_size: 1
+fieldset/CPU_INT:
+  description: Interrupt mask.
+  fields:
+  - name: PER
+    description: Parity error event mask.
+    bit_offset: 0
+    bit_size: 1
+  - name: RXFIFO_OVF
+    description: RXFIFO overflow event mask.
+    bit_offset: 1
+    bit_size: 1
+  - name: RX
+    description: Mask Receive Event.
+    bit_offset: 2
+    bit_size: 1
+  - name: RXFULL
+    description: RX FIFO Full Interrupt Mask.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXFIFO_UNF
+    description: TX FIFO underflow interrupt mask.
+    bit_offset: 4
+    bit_size: 1
+  - name: TX
+    description: Mask Transmit Event.
+    bit_offset: 5
+    bit_size: 1
+  - name: TXEMPTY
+    description: Transmit FIFO Empty event mask.
+    bit_offset: 6
+    bit_size: 1
+  - name: IDLE
+    description: SPI Idle event mask.
+    bit_offset: 8
+    bit_size: 1
+  - name: RTOUT
+    description: Enable SPI Receive Time-Out event mask.
+    bit_offset: 9
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: Enable DMA Done on RX Event Channel Interrupt.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: Enable DMA Done on TX Event Channel Interrupt.
+    bit_offset: 16
+    bit_size: 1
+  - name: LTOUT
+    description: Enable SPI Line Time-Out event mask.
+    bit_offset: 20
+    bit_size: 1
+fieldset/CTL0:
+  description: SPI control register 0.
+  fields:
+  - name: DSS
+    description: 'Data Size Select. Values 0 - 2 are reserved and shall not be used. 3h = 4_BIT : 4-bit data SPI allows only values up to 16 Bit.'
+    bit_offset: 0
+    bit_size: 5
+    enum: DSS
+  - name: FRF
+    description: Frame format Select.
+    bit_offset: 5
+    bit_size: 2
+    enum: FRF
+  - name: SPO
+    description: CLKOUT polarity (Motorola SPI frame format only).
+    bit_offset: 8
+    bit_size: 1
+  - name: SPH
+    description: CLKOUT phase (Motorola SPI frame format only) This bit selects the clock edge that captures data and enables it to change state. It has the most impact on the first bit transmitted by either permitting or not permitting a clock transition before the first data capture edge.
+    bit_offset: 9
+    bit_size: 1
+    enum: SPH
+  - name: CSSEL
+    description: Select the CS line to control on data transfer This bit is applicable for both controller/target mode.
+    bit_offset: 12
+    bit_size: 2
+    enum: CSSEL
+  - name: CSCLR
+    description: Clear shift register counter on CS inactive This bit is relevant only in the peripheral, CTL1.CP=0.
+    bit_offset: 14
+    bit_size: 1
+fieldset/CTL1:
+  description: SPI control register 1.
+  fields:
+  - name: ENABLE
+    description: SPI enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: LBM
+    description: Loop back mode.
+    bit_offset: 1
+    bit_size: 1
+  - name: CP
+    description: Controller or peripheral mode select. This bit can be modified only when SPI is disabled, CTL1.ENABLE=0.
+    bit_offset: 2
+    bit_size: 1
+  - name: POD
+    description: 'Peripheral-mode: Data output disabled This bit is relevant only in Peripheral mode. In multiple-peripheral system topologies, SPI controller can broadcast a message to all peripherals, while only one peripheral drives the line. POD can be used by the SPI peripheral to disable driving data on the line.'
+    bit_offset: 3
+    bit_size: 1
+  - name: MSB
+    description: MSB first select. Controls the direction of the receive and transmit shift register.
+    bit_offset: 4
+    bit_size: 1
+  - name: PREN
+    description: Parity receive enable If enabled, parity reception check will be done for both controller and peripheral modes In case of a parity miss-match the parity error flag RIS.PER will be set.
+    bit_offset: 5
+    bit_size: 1
+  - name: PES
+    description: Even Parity Select.
+    bit_offset: 6
+    bit_size: 1
+  - name: PTEN
+    description: Parity transmit enable If enabled, parity transmission will be done for both controller and peripheral modes.
+    bit_offset: 8
+    bit_size: 1
+  - name: SUSPEND
+    description: Suspend external communication.
+    bit_offset: 9
+    bit_size: 1
+  - name: CDENABLE
+    description: Command/Data Mode enable.
+    bit_offset: 11
+    bit_size: 1
+  - name: CDMODE
+    description: 'Command/Data Mode Value When CTL1.CDENABLE is 1, CS3 line is used as C/D signal to distinguish between Command (C/D low) and Data (C/D high) information. When a value is written into the CTL1.CDMODE bits, the C/D (CS3) line will go low for the given numbers of byte which are sent by the SPI, starting with the next value to be transmitted after which, C/D line will go high automatically 0: Manual mode with C/D signal as High 1-14: C/D is low while this number of bytes are being sent after which, this field sets to 0 and C/D goes high. Reading this field at any time returns the remaining number of command bytes. 15: Manual mode with C/D signal as Low.'
+    bit_offset: 12
+    bit_size: 4
+    enum: CTL1_CDMODE
+  - name: REPEATTX
+    description: 'Counter to repeat last transfer 0: repeat last transfer is disabled. x: repeat the last transfer with the given number. The transfer will be started with writing a data into the TX Buffer. Sending the data will be repeated with the given value, so the data will be transferred X+1 times in total. The behavior is identical as if the data would be written into the TX Buffer that many times as defined by the value here. It can be used to clean a transfer or to pull a certain amount of data by a peripheral.'
+    bit_offset: 16
+    bit_size: 8
+    enum: REPEATTX
+  - name: RXTIMEOUT
+    description: Receive Timeout (only for Peripheral mode) Defines the number of Clock Cycles before after which the Receive Timeout flag RTOUT is set. The time is calculated using the control register for the clock selection and divider in the Controller mode configuration. A value of 0 disables this function.
+    bit_offset: 24
+    bit_size: 6
+fieldset/DMA_TRIG_RX:
+  description: Interrupt mask.
+  fields:
+  - name: RX
+    description: Receive FIFO event mask.
+    bit_offset: 2
+    bit_size: 1
+  - name: RTOUT
+    description: SPI Receive Time-Out event mask.
+    bit_offset: 9
+    bit_size: 1
+fieldset/DMA_TRIG_TX:
+  description: Interrupt mask.
+  fields:
+  - name: TX
+    description: Transmit FIFO event mask.
+    bit_offset: 5
+    bit_size: 1
+fieldset/ICLR:
+  description: Interrupt clear.
+  fields:
+  - name: PER
+    description: Clear Parity error event.
+    bit_offset: 0
+    bit_size: 1
+  - name: RXFIFO_OVF
+    description: Clear RXFIFO overflow event.
+    bit_offset: 1
+    bit_size: 1
+  - name: RX
+    description: Clear Receive event.
+    bit_offset: 2
+    bit_size: 1
+  - name: RXFULL
+    description: Clear RX FIFO underflow event.
+    bit_offset: 3
+    bit_size: 1
+  - name: TXFIFO_UNF
+    description: Clear TXFIFO underflow event.
+    bit_offset: 4
+    bit_size: 1
+  - name: TX
+    description: Clear Transmit event.
+    bit_offset: 5
+    bit_size: 1
+  - name: TXEMPTY
+    description: Clear Transmit FIFO Empty event.
+    bit_offset: 6
+    bit_size: 1
+  - name: IDLE
+    description: Clear SPI IDLE mode event.
+    bit_offset: 8
+    bit_size: 1
+  - name: RTOUT
+    description: Clear SPI Receive Time-Out Event.
+    bit_offset: 9
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: Clear DMA Done on RX Event Channel Interrupt.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: Clear DMA Done on TX Event Channel Interrupt.
+    bit_offset: 16
+    bit_size: 1
+  - name: LTOUT
+    description: Clear SPI Line Time-Out Event.
+    bit_offset: 20
+    bit_size: 1
+fieldset/IFLS:
+  description: Interrupt FIFO Level Select Register.
+  fields:
+  - name: TXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 0
+    bit_size: 3
+    enum: TXIFLSEL
+  - name: TXCLR
+    description: TX FIFO CLEAR. Setting this bit will clear the TX FIFO contents.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 4
+    bit_size: 3
+    enum: RXIFLSEL
+  - name: RXCLR
+    description: RX FIFO CLEAR. Setting this bit will clear the RX FIFO contents.
+    bit_offset: 7
+    bit_size: 1
+fieldset/IIDX:
+  description: Interrupt Index Register.
+  fields:
+  - name: STAT
+    description: Interrupt index status.
+    bit_offset: 0
+    bit_size: 8
+    enum: STAT
+fieldset/INTCTL:
+  description: Interrupt control register.
+  fields:
+  - name: INTEVAL
+    description: Writing a 1 to this field re-evaluates the interrupt sources.
+    bit_offset: 0
+    bit_size: 1
+fieldset/PDBGCTL:
+  description: Peripheral Debug Control.
+  fields:
+  - name: FREE
+    description: Free run control.
+    bit_offset: 0
+    bit_size: 1
+  - name: SOFT
+    description: Soft halt boundary control. This function is only available, if [FREE] is set to 'STOP'.
+    bit_offset: 1
+    bit_size: 1
+    enum: SOFT
+fieldset/RXDATA:
+  description: RXDATA Register.
+  fields:
+  - name: DATA
+    description: Received Data When PACKEN=1,two entries of the FIFO are returned as a 32-bit value. When PACKEN=0, 1 entry of FIFO is returned as 16-bit value. As data values are removed by the receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. Received data less than 16 bits is automatically right justified in the receive buffer.
+    bit_offset: 0
+    bit_size: 16
+fieldset/STAT:
+  description: Status Register.
+  fields:
+  - name: RXFE
+    description: Receive FIFO empty.
+    bit_offset: 2
+    bit_size: 1
+  - name: RXFF
+    description: Receive FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXCLR
+    description: RX FIFO Clear Status.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXFE
+    description: Transmit FIFO empty.
+    bit_offset: 5
+    bit_size: 1
+  - name: TXFF
+    description: Transmit FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 6
+    bit_size: 1
+  - name: TXCLR
+    description: TX FIFO Clear Status.
+    bit_offset: 7
+    bit_size: 1
+  - name: BUSY
+    description: Busy.
+    bit_offset: 8
+    bit_size: 1
+    enum: BUSY
+  - name: CDMODE
+    description: Current CDMODE status. This reflects the current counter counter value.
+    bit_offset: 12
+    bit_size: 4
+    enum: STAT_CDMODE
+fieldset/TXDATA:
+  description: TXDATA Register.
+  fields:
+  - name: DATA
+    description: Transmit Data When read, last written value will be returned. If the last write to this field was a 32-bit write (with PACKEN=1), 32-bits will be returned and if the last write was a 16-bit write (PACKEN=0), those 16-bits will be returned. When written, one or two FIFO entries will be written depending on PACKEN value. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the TXD output pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits.
+    bit_offset: 0
+    bit_size: 16
+enum/BUSY:
+  bit_size: 1
+  variants:
+  - name: IDLE
+    description: SPI is in idle mode.
+    value: 0
+  - name: ACTIVE
+    description: SPI is currently transmitting and/or receiving data.
+    value: 1
+enum/CSSEL:
+  bit_size: 2
+  variants:
+  - name: CSSEL_0
+    description: 'CS line select: 0.'
+    value: 0
+  - name: CSSEL_1
+    description: 'CS line select: 1.'
+    value: 1
+  - name: CSSEL_2
+    description: 'CS line select: 2.'
+    value: 2
+  - name: CSSEL_3
+    description: 'CS line select: 3.'
+    value: 3
+enum/CTL1_CDMODE:
+  bit_size: 4
+  variants:
+  - name: DATA
+    description: 'Manual mode: Data.'
+    value: 0
+  - name: COMMAND
+    description: 'Manual mode: Command.'
+    value: 15
+enum/DSS:
+  bit_size: 5
+  variants:
+  - name: DSS_4
+    description: 'Data Size Select bits: 4.'
+    value: 3
+  - name: DSS_5
+    description: 'Data Size Select bits: 5.'
+    value: 4
+  - name: DSS_6
+    description: 'Data Size Select bits: 6.'
+    value: 5
+  - name: DSS_7
+    description: 'Data Size Select bits: 7.'
+    value: 6
+  - name: DSS_8
+    description: 'Data Size Select bits: 8.'
+    value: 7
+  - name: DSS_9
+    description: 'Data Size Select bits: 9.'
+    value: 8
+  - name: DSS_10
+    description: 'Data Size Select bits: 10.'
+    value: 9
+  - name: DSS_11
+    description: 'Data Size Select bits: 11.'
+    value: 10
+  - name: DSS_12
+    description: 'Data Size Select bits: 12.'
+    value: 11
+  - name: DSS_13
+    description: 'Data Size Select bits: 13.'
+    value: 12
+  - name: DSS_14
+    description: 'Data Size Select bits: 14.'
+    value: 13
+  - name: DSS_15
+    description: 'Data Size Select bits: 15.'
+    value: 14
+  - name: DSS_16
+    description: 'Data Size Select bits: 16.'
+    value: 15
+enum/FRF:
+  bit_size: 2
+  variants:
+  - name: MOTOROLA_3WIRE
+    description: Motorola SPI frame format (3 wire mode).
+    value: 0
+  - name: MOTOROLA_4WIRE
+    description: Motorola SPI frame format (4 wire mode).
+    value: 1
+  - name: TI_SYNC
+    description: TI synchronous serial frame format.
+    value: 2
+enum/RATIO:
+  bit_size: 3
+  variants:
+  - name: DIV_BY_1
+    description: Do not divide clock source.
+    value: 0
+  - name: DIV_BY_2
+    description: Divide clock source by 2.
+    value: 1
+  - name: DIV_BY_3
+    description: Divide clock source by 3.
+    value: 2
+  - name: DIV_BY_4
+    description: Divide clock source by 4.
+    value: 3
+  - name: DIV_BY_5
+    description: Divide clock source by 5.
+    value: 4
+  - name: DIV_BY_6
+    description: Divide clock source by 6.
+    value: 5
+  - name: DIV_BY_7
+    description: Divide clock source by 7.
+    value: 6
+  - name: DIV_BY_8
+    description: Divide clock source by 8.
+    value: 7
+enum/REPEATTX:
+  bit_size: 8
+  variants:
+  - name: DISABLE
+    description: REPEATTX disable.
+    value: 0
+enum/RXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_1_4
+    description: RX FIFO >= 1/4 full.
+    value: 1
+  - name: LVL_1_2
+    description: RX FIFO >= 1/2 full (default).
+    value: 2
+  - name: LVL_3_4
+    description: RX FIFO >= 3/4 full.
+    value: 3
+  - name: LVL_NOT_EMPTY
+    description: Opposite of empty.
+    value: 4
+  - name: LVL_FULL
+    description: RX FIFO is full.
+    value: 5
+  - name: LVL_ALMOST_FULL
+    description: RX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 6
+  - name: LVL_ALMOST_EMPTY
+    description: RX_FIFO <= 1.
+    value: 7
+enum/SOFT:
+  bit_size: 1
+  variants:
+  - name: DEPRECATED
+    description: Not supported.
+    value: 0
+  - name: DELAYED
+    description: The peripheral blocks the debug freeze until it has reached a boundary where it can resume without corruption.
+    value: 1
+enum/SPH:
+  bit_size: 1
+  variants:
+  - name: FIRST
+    description: Data is captured on the first clock edge transition.
+    value: 0
+  - name: SECOND
+    description: Data is captured on the second clock edge transition.
+    value: 1
+enum/STAT:
+  bit_size: 8
+  variants:
+  - name: NO_INTR
+    description: No interrupt pending.
+    value: 0
+  - name: PER_EVT
+    description: Transmit Parity Event/interrupt pending.
+    value: 1
+  - name: RXFIFO_OFV_EVT
+    description: RX FIFO Overflow Event/interrupt pending.
+    value: 2
+  - name: RX_EVT
+    description: Receive interrupt.
+    value: 3
+  - name: RXFULL_EVT
+    description: RX FIFO Full Interrupt.
+    value: 4
+  - name: TXFIFO_UNF_EVT
+    description: TX FIFO underflow interrupt.
+    value: 5
+  - name: TX_EVT
+    description: Transmit Event.
+    value: 6
+  - name: TX_EMPTY
+    description: Transmit Buffer Empty Event/interrupt pending.
+    value: 7
+  - name: IDLE_EVT
+    description: End of Transmit Event/interrupt pending.
+    value: 9
+  - name: RTOUT_EVT
+    description: SPI receive time-out interrupt.
+    value: 10
+  - name: DMA_DONE_RX
+    description: DMA DONE on RX.
+    value: 16
+  - name: DMA_DONE_TX
+    description: DMA DONE on TX.
+    value: 17
+  - name: DMA_PREIRQ_RX
+    description: DMA PRE IRQ RX INTERRUPT.
+    value: 19
+  - name: DMA_PREIRQ_TX
+    description: DMA PRE IRQ TX INTERRUPT.
+    value: 20
+  - name: LTOUT
+    description: SPI line time-out interrupt.
+    value: 21
+enum/STAT_CDMODE:
+  bit_size: 4
+  variants:
+  - name: DATA
+    description: 'Manual mode: Data.'
+    value: 0
+  - name: COMMAND
+    description: 'Manual mode: Command.'
+    value: 15
+enum/TXIFLSEL:
+  bit_size: 3
+  variants:
+  - name: LVL_3_4
+    description: TX FIFO <= 3/4 empty.
+    value: 1
+  - name: LVL_1_2
+    description: TX FIFO <= 1/2 empty (default).
+    value: 2
+  - name: LVL_1_4
+    description: TX FIFO <= 1/4 empty.
+    value: 3
+  - name: LVL_NOT_FULL
+    description: Opposite of full.
+    value: 4
+  - name: LVL_EMPTY
+    description: TX FIFO is empty.
+    value: 5
+  - name: LVL_ALMOST_EMPTY
+    description: TX FIFO <= 1.
+    value: 6
+  - name: LVL_ALMOST_FULL
+    description: TX_FIFO >= (MAX_FIFO_LEN -1).
+    value: 7

--- a/data/registers/unicommspi_v1.yaml
+++ b/data/registers/unicommspi_v1.yaml
@@ -28,7 +28,7 @@ block/CPU_INT:
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: ICLR
+    fieldset: CPU_INT
 block/DMA_TRIG_RX:
   items:
   - name: IMASK
@@ -303,12 +303,11 @@ fieldset/CTL1:
     description: 'Command/Data Mode Value When CTL1.CDENABLE is 1, CS3 line is used as C/D signal to distinguish between Command (C/D low) and Data (C/D high) information. When a value is written into the CTL1.CDMODE bits, the C/D (CS3) line will go low for the given numbers of byte which are sent by the SPI, starting with the next value to be transmitted after which, C/D line will go high automatically 0: Manual mode with C/D signal as High 1-14: C/D is low while this number of bytes are being sent after which, this field sets to 0 and C/D goes high. Reading this field at any time returns the remaining number of command bytes. 15: Manual mode with C/D signal as Low.'
     bit_offset: 12
     bit_size: 4
-    enum: CTL1_CDMODE
+    enum: CDMODE
   - name: REPEATTX
     description: 'Counter to repeat last transfer 0: repeat last transfer is disabled. x: repeat the last transfer with the given number. The transfer will be started with writing a data into the TX Buffer. Sending the data will be repeated with the given value, so the data will be transferred X+1 times in total. The behavior is identical as if the data would be written into the TX Buffer that many times as defined by the value here. It can be used to clean a transfer or to pull a certain amount of data by a peripheral.'
     bit_offset: 16
     bit_size: 8
-    enum: REPEATTX
   - name: RXTIMEOUT
     description: Receive Timeout (only for Peripheral mode) Defines the number of Clock Cycles before after which the Receive Timeout flag RTOUT is set. The time is calculated using the control register for the clock selection and divider in the Controller mode configuration. A value of 0 disables this function.
     bit_offset: 24
@@ -330,57 +329,6 @@ fieldset/DMA_TRIG_TX:
   - name: TX
     description: Transmit FIFO event mask.
     bit_offset: 5
-    bit_size: 1
-fieldset/ICLR:
-  description: Interrupt clear.
-  fields:
-  - name: PER
-    description: Clear Parity error event.
-    bit_offset: 0
-    bit_size: 1
-  - name: RXFIFO_OVF
-    description: Clear RXFIFO overflow event.
-    bit_offset: 1
-    bit_size: 1
-  - name: RX
-    description: Clear Receive event.
-    bit_offset: 2
-    bit_size: 1
-  - name: RXFULL
-    description: Clear RX FIFO underflow event.
-    bit_offset: 3
-    bit_size: 1
-  - name: TXFIFO_UNF
-    description: Clear TXFIFO underflow event.
-    bit_offset: 4
-    bit_size: 1
-  - name: TX
-    description: Clear Transmit event.
-    bit_offset: 5
-    bit_size: 1
-  - name: TXEMPTY
-    description: Clear Transmit FIFO Empty event.
-    bit_offset: 6
-    bit_size: 1
-  - name: IDLE
-    description: Clear SPI IDLE mode event.
-    bit_offset: 8
-    bit_size: 1
-  - name: RTOUT
-    description: Clear SPI Receive Time-Out Event.
-    bit_offset: 9
-    bit_size: 1
-  - name: DMA_DONE_RX
-    description: Clear DMA Done on RX Event Channel Interrupt.
-    bit_offset: 15
-    bit_size: 1
-  - name: DMA_DONE_TX
-    description: Clear DMA Done on TX Event Channel Interrupt.
-    bit_offset: 16
-    bit_size: 1
-  - name: LTOUT
-    description: Clear SPI Line Time-Out Event.
-    bit_offset: 20
     bit_size: 1
 fieldset/IFLS:
   description: Interrupt FIFO Level Select Register.
@@ -468,12 +416,11 @@ fieldset/STAT:
     description: Busy.
     bit_offset: 8
     bit_size: 1
-    enum: BUSY
   - name: CDMODE
     description: Current CDMODE status. This reflects the current counter counter value.
     bit_offset: 12
     bit_size: 4
-    enum: STAT_CDMODE
+    enum: CDMODE
 fieldset/TXDATA:
   description: TXDATA Register.
   fields:
@@ -481,15 +428,15 @@ fieldset/TXDATA:
     description: Transmit Data When read, last written value will be returned. If the last write to this field was a 32-bit write (with PACKEN=1), 32-bits will be returned and if the last write was a 16-bit write (PACKEN=0), those 16-bits will be returned. When written, one or two FIFO entries will be written depending on PACKEN value. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the TXD output pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits.
     bit_offset: 0
     bit_size: 16
-enum/BUSY:
-  bit_size: 1
+enum/CDMODE:
+  bit_size: 4
   variants:
-  - name: IDLE
-    description: SPI is in idle mode.
+  - name: DATA
+    description: 'Manual mode: Data.'
     value: 0
-  - name: ACTIVE
-    description: SPI is currently transmitting and/or receiving data.
-    value: 1
+  - name: COMMAND
+    description: 'Manual mode: Command.'
+    value: 15
 enum/CSSEL:
   bit_size: 2
   variants:
@@ -505,15 +452,6 @@ enum/CSSEL:
   - name: CSSEL_3
     description: 'CS line select: 3.'
     value: 3
-enum/CTL1_CDMODE:
-  bit_size: 4
-  variants:
-  - name: DATA
-    description: 'Manual mode: Data.'
-    value: 0
-  - name: COMMAND
-    description: 'Manual mode: Command.'
-    value: 15
 enum/DSS:
   bit_size: 5
   variants:
@@ -595,12 +533,6 @@ enum/RATIO:
   - name: DIV_BY_8
     description: Divide clock source by 8.
     value: 7
-enum/REPEATTX:
-  bit_size: 8
-  variants:
-  - name: DISABLE
-    description: REPEATTX disable.
-    value: 0
 enum/RXIFLSEL:
   bit_size: 3
   variants:
@@ -691,15 +623,6 @@ enum/STAT:
   - name: LTOUT
     description: SPI line time-out interrupt.
     value: 21
-enum/STAT_CDMODE:
-  bit_size: 4
-  variants:
-  - name: DATA
-    description: 'Manual mode: Data.'
-    value: 0
-  - name: COMMAND
-    description: 'Manual mode: Command.'
-    value: 15
 enum/TXIFLSEL:
   bit_size: 3
   variants:

--- a/data/registers/unicommuart_v1.yaml
+++ b/data/registers/unicommuart_v1.yaml
@@ -1,0 +1,885 @@
+block/CPU_INT:
+  items:
+  - name: IIDX
+    description: Interrupt index.
+    byte_offset: 0
+    access: Read
+    fieldset: IIDX
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: CPU_INT
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: CPU_INT
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: CPU_INT
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: CPU_INT
+  - name: ICLR
+    description: Interrupt clear.
+    byte_offset: 40
+    access: Write
+    fieldset: ICLR
+block/DMA_TRIG_RX:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG_RX
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG_RX
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG_RX
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG_RX
+block/DMA_TRIG_TX:
+  items:
+  - name: IMASK
+    description: Interrupt mask.
+    byte_offset: 8
+    fieldset: DMA_TRIG_TX
+  - name: RIS
+    description: Raw interrupt status.
+    byte_offset: 16
+    access: Read
+    fieldset: DMA_TRIG_TX
+  - name: MIS
+    description: Masked interrupt status.
+    byte_offset: 24
+    access: Read
+    fieldset: DMA_TRIG_TX
+  - name: ISET
+    description: Interrupt set.
+    byte_offset: 32
+    access: Write
+    fieldset: DMA_TRIG_TX
+block/UNICOMMUART:
+  description: PERIPHERALREGION.
+  items:
+  - name: CLKDIV
+    description: Clock Divider.
+    byte_offset: 4096
+    fieldset: CLKDIV
+  - name: CLKSEL
+    description: Clock Select for Ultra Low Power peripherals.
+    byte_offset: 4104
+    fieldset: CLKSEL
+  - name: PDBGCTL
+    description: Peripheral Debug Control.
+    byte_offset: 4120
+    fieldset: PDBGCTL
+  - name: CPU_INT
+    array:
+      len: 1
+      stride: 44
+    byte_offset: 4128
+    block: CPU_INT
+  - name: DMA_TRIG_RX
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4176
+    block: DMA_TRIG_RX
+  - name: DMA_TRIG_TX
+    array:
+      len: 1
+      stride: 36
+    byte_offset: 4224
+    block: DMA_TRIG_TX
+  - name: INTCTL
+    description: Interrupt control register.
+    byte_offset: 4324
+    access: Write
+    fieldset: INTCTL
+  - name: CTL0
+    description: UART Control Register 0.
+    byte_offset: 4352
+    fieldset: CTL0
+  - name: LCRH
+    description: UART Line Control Register.
+    byte_offset: 4356
+    fieldset: LCRH
+  - name: STAT
+    description: UART Status Register.
+    byte_offset: 4360
+    access: Read
+    fieldset: STAT
+  - name: IFLS
+    description: UART Interrupt FIFO Level Select Register.
+    byte_offset: 4364
+    fieldset: IFLS
+  - name: IBRD
+    description: UART Integer Baud-Rate Divisor Register.
+    byte_offset: 4368
+    fieldset: IBRD
+  - name: FBRD
+    description: UART Fractional Baud-Rate Divisor Register.
+    byte_offset: 4372
+    fieldset: FBRD
+  - name: GFCTL
+    description: Glitch Filter Control.
+    byte_offset: 4376
+    fieldset: GFCTL
+  - name: TXDATA
+    description: UART Transmit Data Register.
+    byte_offset: 4384
+    access: Write
+    fieldset: TXDATA
+  - name: RXDATA
+    description: UART Receive Data Register.
+    byte_offset: 4388
+    access: Read
+    fieldset: RXDATA
+  - name: LINCNT
+    description: UART LIN Mode Counter Register.
+    byte_offset: 4400
+    fieldset: LINCNT
+  - name: LINCTL
+    description: UART LIN Mode Control Register.
+    byte_offset: 4404
+    fieldset: LINCTL
+  - name: LINC0
+    description: UART LIN Mode Capture 0 Register.
+    byte_offset: 4408
+    fieldset: LINC
+  - name: LINC1
+    description: UART LIN Mode Capture 1 Register.
+    byte_offset: 4412
+    fieldset: LINC
+  - name: IRCTL
+    description: eUSCI_Ax IrDA Control Word Register.
+    byte_offset: 4416
+    fieldset: IRCTL
+  - name: AMASK
+    description: Self Address Mask Register.
+    byte_offset: 4424
+    fieldset: AMASK
+  - name: ADDR
+    description: Self Address Register.
+    byte_offset: 4428
+    fieldset: ADDR
+fieldset/ADDR:
+  description: Self Address Register.
+  fields:
+  - name: ADDR
+    description: Self Address for 9-Bit Mode This field contains the address that should be matched when UARTxAMASK is FFh.
+    bit_offset: 0
+    bit_size: 8
+fieldset/AMASK:
+  description: Self Address Mask Register.
+  fields:
+  - name: MSK
+    description: Self Address Mask for 9-Bit Mode This field contains the address mask that creates a set of addresses that should be matched. A 0 bit in the MSK bitfield configures, that the corresponding bit in the ADDR bitfield of the UARTxADDR register is don't care. A 1 bit in the MSK bitfield configures, that the corresponding bit in the ADDR bitfield of the UARTxADDR register must match.
+    bit_offset: 0
+    bit_size: 8
+fieldset/CLKDIV:
+  description: Clock Divider.
+  fields:
+  - name: RATIO
+    description: 'Divide ratio of the module clock, as the divisor minus one: 0 divides by 1 and 63 by 64.'
+    bit_offset: 0
+    bit_size: 6
+fieldset/CLKSEL:
+  description: Clock Select for Ultra Low Power peripherals.
+  fields:
+  - name: LFCLK_SEL
+    description: Selects LFCLK as clock source if enabled.
+    bit_offset: 1
+    bit_size: 1
+  - name: MFCLK_SEL
+    description: Selects MFCLK as clock source if enabled.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSCLK_SEL
+    description: Selects BUS CLK as clock source if enabled.
+    bit_offset: 3
+    bit_size: 1
+fieldset/CPU_INT:
+  description: Interrupt mask.
+  fields:
+  - name: RTOUT
+    description: Enable UARTOUT Receive Time-Out Interrupt.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRMERR
+    description: Enable UART Framing Error Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: PARERR
+    description: Enable UART Parity Error Interrupt.
+    bit_offset: 2
+    bit_size: 1
+  - name: BRKERR
+    description: Enable UART Break Error Interrupt.
+    bit_offset: 3
+    bit_size: 1
+  - name: OVRERR
+    description: Enable UART Receive Overrun Error Interrupt.
+    bit_offset: 4
+    bit_size: 1
+  - name: RXNE
+    description: Enable Negative Edge on UARTxRXD Interrupt.
+    bit_offset: 5
+    bit_size: 1
+  - name: RXPE
+    description: Enable Positive Edge on UARTxRXD Interrupt.
+    bit_offset: 6
+    bit_size: 1
+  - name: LINC0
+    description: Enable LIN Capture 0 / Match Interrupt.
+    bit_offset: 7
+    bit_size: 1
+  - name: LINC1
+    description: Enable LIN Capture 1 Interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: LINOVF
+    description: Enable LIN Hardware Counter Overflow Interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: RXINT
+    description: Enable UART Receive Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: TXINT
+    description: Enable UART Transmit Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: EOT
+    description: Enable UART End of Transmission Interrupt Indicates that the last bit of all transmitted data and flags has left the serializer and without any further Data in the TX Fifo or Buffer.
+    bit_offset: 12
+    bit_size: 1
+  - name: ADDR_MATCH
+    description: Enable Address Match Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: CTS
+    description: Enable UART Clear to Send Modem Interrupt.
+    bit_offset: 14
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: Enable DMA Done on RX Event Channel Interrupt.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: Enable DMA Done on TX Event Channel Interrupt.
+    bit_offset: 16
+    bit_size: 1
+  - name: NERR
+    description: Noise Error on triple voting. Asserted when the 3 samples of majority voting are not equal.
+    bit_offset: 17
+    bit_size: 1
+  - name: LTOUT
+    description: Enable UARTOUT Line Time-Out Interrupt.
+    bit_offset: 20
+    bit_size: 1
+fieldset/CTL0:
+  description: UART Control Register 0.
+  fields:
+  - name: ENABLE
+    description: UART Module Enable. If the UART is disabled in the middle of transmission or reception, it completes the current character before stopping. If the ENABLE bit is not set, all registers can still be accessed and updated. It is recommended to setup and change the UART operation mode with having the ENABLE bit cleared to avoid unpredictable behavior during the setup or update. If disabled the UART module will not send or receive any data and the logic is held in reset state.
+    bit_offset: 0
+    bit_size: 1
+  - name: LBE
+    description: UART Loop Back Enable.
+    bit_offset: 2
+    bit_size: 1
+  - name: RXE
+    description: 'UART Receive Enable If the UART is disabled in the middle of a receive, it completes the current character before stopping. #b#NOTE:#/b# To enable reception, the UARTEN bit must be set.'
+    bit_offset: 3
+    bit_size: 1
+  - name: TXE
+    description: 'UART Transmit Enable If the UART is disabled in the middle of a transmission, it completes the current character before stopping. #b#NOTE:#/b# To enable transmission, the UARTEN bit must be set.'
+    bit_offset: 4
+    bit_size: 1
+  - name: TXD_OUT_EN
+    description: TXD Pin Control Enable. When the transmit section of the UART is disabled (TXE = 0), the TXD pin can be controlled by the TXD_OUT bit.
+    bit_offset: 5
+    bit_size: 1
+  - name: TXD_OUT
+    description: TXD Pin Control Controls the TXD pin when TXD_OUT_EN = 1 and TXE = 0.
+    bit_offset: 6
+    bit_size: 1
+  - name: MENC
+    description: Manchester Encode enable.
+    bit_offset: 7
+    bit_size: 1
+  - name: MODE
+    description: 'Set the communication mode and protocol used. (Not defined settings uses the default setting: 0).'
+    bit_offset: 8
+    bit_size: 3
+    enum: MODE
+  - name: RTS
+    description: Request to Send If RTSEN is set the RTS output signals is controlled by the hardware logic using the FIFO fill level or buffer status. If RTSEN is cleared the RTS output is controlled by the RTS bit. The bit is the complement of the UART request to send, RTS modem status output.
+    bit_offset: 12
+    bit_size: 1
+  - name: RTSEN
+    description: Enable hardware controlled Request to Send.
+    bit_offset: 13
+    bit_size: 1
+  - name: CTSEN
+    description: Enable Clear To Send.
+    bit_offset: 14
+    bit_size: 1
+  - name: HSE
+    description: 'High-Speed Bit Oversampling Enable #b#NOTE:#/b# The bit oversampling influences the UART baud-rate configuration. The state of this bit has no effect on clock generation in ISO7816 smart card mode (the SMART bit is set).'
+    bit_offset: 15
+    bit_size: 2
+    enum: HSE
+  - name: MAJVOTE
+    description: 'Majority Vote Enable When Majority Voting is enabled, the three center bits are used to determine received sample value. In case of error (i.e. all 3 bits are not the same), noise error is detected and bits RIS.NERR and register RXDATA.NERR are set. Oversampling of 16 : bits 7, 8, 9 are used Oversampling of 8 : bits 3, 4, 5 are used Disabled : Single sample value (center value) used.'
+    bit_offset: 18
+    bit_size: 1
+  - name: MSBFIRST
+    description: 'Most Significant Bit First This bit has effect both on the way protocol byte is transmitted and received. Notes: User needs to match the protocol to the correct value of this bit to send MSb or LSb first. The hardware engine will send the byte entirely based on this bit.'
+    bit_offset: 19
+    bit_size: 1
+fieldset/DMA_TRIG_RX:
+  description: Interrupt mask.
+  fields:
+  - name: RTOUT
+    description: Enable UARTOUT Receive Time-Out Interrupt.
+    bit_offset: 0
+    bit_size: 1
+  - name: RXINT
+    description: Enable UART Receive Interrupt.
+    bit_offset: 10
+    bit_size: 1
+fieldset/DMA_TRIG_TX:
+  description: Interrupt mask.
+  fields:
+  - name: TXINT
+    description: Enable UART Transmit Interrupt.
+    bit_offset: 11
+    bit_size: 1
+fieldset/FBRD:
+  description: UART Fractional Baud-Rate Divisor Register.
+  fields:
+  - name: DIVFRAC
+    description: Fractional Baud-Rate Divisor.
+    bit_offset: 0
+    bit_size: 6
+fieldset/GFCTL:
+  description: Glitch Filter Control.
+  fields:
+  - name: DGFSEL
+    description: 'Glitch Suppression Pulse Width This field controls the pulse width select for glitch suppression on the RX line. The value programmed in this field gives the number of cycles of functional clock up to which the glitch has to be suppressed on the RX line. In IRDA mode: The minimum pulse length for receive is given by: t(MIN) = (DGFSEL) / f(IRTXCLK).'
+    bit_offset: 0
+    bit_size: 6
+fieldset/IBRD:
+  description: UART Integer Baud-Rate Divisor Register.
+  fields:
+  - name: DIVINT
+    description: Integer Baud-Rate Divisor.
+    bit_offset: 0
+    bit_size: 16
+fieldset/ICLR:
+  description: Interrupt clear.
+  fields:
+  - name: RTOUT
+    description: Clear UARTOUT Receive Time-Out Interrupt.
+    bit_offset: 0
+    bit_size: 1
+  - name: FRMERR
+    description: Clear UART Framing Error Interrupt.
+    bit_offset: 1
+    bit_size: 1
+  - name: PARERR
+    description: Clear UART Parity Error Interrupt.
+    bit_offset: 2
+    bit_size: 1
+  - name: BRKERR
+    description: Clear UART Break Error Interrupt.
+    bit_offset: 3
+    bit_size: 1
+  - name: OVRERR
+    description: Clear UART Receive Overrun Error Interrupt.
+    bit_offset: 4
+    bit_size: 1
+  - name: RXNE
+    description: Clear Negative Edge on UARTxRXD Interrupt.
+    bit_offset: 5
+    bit_size: 1
+  - name: RXPE
+    description: Clear Positive Edge on UARTxRXD Interrupt.
+    bit_offset: 6
+    bit_size: 1
+  - name: LINC0
+    description: Clear LIN Capture 0 / Match Interrupt.
+    bit_offset: 7
+    bit_size: 1
+  - name: LINC1
+    description: Clear LIN Capture 1 Interrupt.
+    bit_offset: 8
+    bit_size: 1
+  - name: LINOVF
+    description: Clear LIN Hardware Counter Overflow Interrupt.
+    bit_offset: 9
+    bit_size: 1
+  - name: RXINT
+    description: Clear UART Receive Interrupt.
+    bit_offset: 10
+    bit_size: 1
+  - name: TXINT
+    description: Clear UART Transmit Interrupt.
+    bit_offset: 11
+    bit_size: 1
+  - name: EOT
+    description: Clear UART End of Transmission Interrupt Indicates that the last bit of all transmitted data and flags has left the serializer and without any further Data in the TX Fifo or Buffer.
+    bit_offset: 12
+    bit_size: 1
+  - name: ADDR_MATCH
+    description: Clear Address Match Interrupt.
+    bit_offset: 13
+    bit_size: 1
+  - name: CTS
+    description: Clear UART Clear to Send Modem Interrupt.
+    bit_offset: 14
+    bit_size: 1
+  - name: DMA_DONE_RX
+    description: Clear DMA Done on RX Event Channel Interrupt.
+    bit_offset: 15
+    bit_size: 1
+  - name: DMA_DONE_TX
+    description: Clear DMA Done on TX Event Channel Interrupt.
+    bit_offset: 16
+    bit_size: 1
+  - name: NERR
+    description: Noise Error on triple voting. Asserted when the 3 samples of majority voting are not equal.
+    bit_offset: 17
+    bit_size: 1
+  - name: LTOUT
+    description: Clear UARTOUT Line Time-Out Interrupt.
+    bit_offset: 20
+    bit_size: 1
+fieldset/IFLS:
+  description: UART Interrupt FIFO Level Select Register.
+  fields:
+  - name: TXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 0
+    bit_size: 3
+    enum: IFLSSEL
+  - name: TXCLR
+    description: TX FIFO CLEAR. Setting this bit will clear the TX FIFO contents.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXIFLSEL
+    description: 'FIFO Level Select for generating events (interrupt/dma). Note: for undefined settings the default configuration is used.'
+    bit_offset: 4
+    bit_size: 3
+    enum: IFLSSEL
+  - name: RXCLR
+    description: RX FIFO CLEAR. Setting this bit will clear the RX FIFO contents.
+    bit_offset: 7
+    bit_size: 1
+  - name: RXTOSEL
+    description: UART Receive Interrupt Timeout Select. When receiving no start edge for an additional character within the set bittimes a RX interrupt is set even if the FIFO level is not reached. A value of 0 disables this function.
+    bit_offset: 8
+    bit_size: 4
+fieldset/IIDX:
+  description: Interrupt index.
+  fields:
+  - name: STAT
+    description: UART Module Interrupt Vector Value. This register provides the highes priority interrupt index. A read clears the corresponding interrupt flag in RIS and MIS registers. 15h-1Fh = Reserved.
+    bit_offset: 0
+    bit_size: 8
+    enum: STAT
+fieldset/INTCTL:
+  description: Interrupt control register.
+  fields:
+  - name: INTEVAL
+    description: Writing a 1 to this field re-evaluates the interrupt sources.
+    bit_offset: 0
+    bit_size: 1
+fieldset/IRCTL:
+  description: eUSCI_Ax IrDA Control Word Register.
+  fields:
+  - name: IREN
+    description: IrDA encoder/decoder enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: IRTXCLK
+    description: IrDA transmit pulse clock select.
+    bit_offset: 1
+    bit_size: 1
+    enum: IRTXCLK
+  - name: IRTXPL
+    description: Transmit pulse length. Pulse length t(PULSE) = (IRTXPLx + 1) / [2 * f(IRTXCLK)] (IRTXCLK = functional clock of the UART).
+    bit_offset: 2
+    bit_size: 6
+  - name: IRRXPL
+    description: IrDA receive input UCAxRXD polarity.
+    bit_offset: 9
+    bit_size: 1
+    enum: IRRXPL
+fieldset/LCRH:
+  description: UART Line Control Register.
+  fields:
+  - name: BRK
+    description: UART Send Break (for LIN Protocol) 1. Break condition is sent on the line for as long as this bit is set.
+    bit_offset: 0
+    bit_size: 1
+  - name: PEN
+    description: UART Parity Enable.
+    bit_offset: 1
+    bit_size: 1
+  - name: EPS
+    description: UART Even Parity Select This bit has no effect when parity is disabled by the PEN bit. For 9-Bit UART Mode transmissions, this bit controls the address byte and data byte indication (9th bit). 0 = The transferred byte is a data byte 1 = The transferred byte is an address byte.
+    bit_offset: 2
+    bit_size: 1
+    enum: EPS
+  - name: STP2
+    description: UART Two Stop Bits Select When in 7816 smart card mode (the SMART bit is set in the UARTCTL register), the number of stop bits is forced to 2.
+    bit_offset: 3
+    bit_size: 1
+  - name: WLEN
+    description: UART Word Length The bits indicate the number of data bits transmitted or received in a frame as follows:.
+    bit_offset: 4
+    bit_size: 2
+    enum: WLEN
+  - name: SPS
+    description: UART Stick Parity Select The Stick Parity Select (SPS) bit is used to set either a permanent '1' or a permanent '0' as parity when transmitting or receiving data. Its purpose is to typically indicate the first byte of a package or to mark an address byte, for example in a multi-drop RS-485 network. When bits PEN, EPS, and SPS of UARTLCRH are set, the parity bit is transmitted and checked as a 0. When bits PEN and SPS are set and EPS is cleared, the parity bit is transmitted and checked as a 1.
+    bit_offset: 6
+    bit_size: 1
+  - name: SENDIDLE
+    description: UART send IDLE pattern. When this bit is set, SENDIDLE period of 11 bit times will be sent on the TX line. Read STAT.SENDIDLE bit to readback current status of SENDIDLE.
+    bit_offset: 7
+    bit_size: 1
+  - name: EXTDIR_SETUP
+    description: Defines the number of UARTclk ticks the signal to control the external driver for the RS485 will be set before the START bit is send.
+    bit_offset: 16
+    bit_size: 5
+  - name: EXTDIR_HOLD
+    description: Defines the number of UARTclk ticks the signal to control the external driver for the RS485 will be reset after the beginning of the stop bit. (If 2 STOP bits are enabled the beginning of the 2nd STOP bit.).
+    bit_offset: 21
+    bit_size: 5
+  - name: SUSPEND
+    description: Suspend external communication.
+    bit_offset: 26
+    bit_size: 1
+fieldset/LINC:
+  description: UART LIN Mode Capture 0 Register.
+  fields:
+  - name: DATA
+    description: 16 Bit Capture / Compare Register Captures current LINCTR value on RXD falling edge and can generate a LINC0 interrupt when capture is enabled (LINC0CAP = 1). If compare mode is enabled (LINC0_MATCH = 1), a counter match can generate a LINC0 interrupt.
+    bit_offset: 0
+    bit_size: 16
+fieldset/LINCNT:
+  description: UART LIN Mode Counter Register.
+  fields:
+  - name: VALUE
+    description: 16 bit up counter clocked by the functional clock of the UART.
+    bit_offset: 0
+    bit_size: 16
+fieldset/LINCTL:
+  description: UART LIN Mode Control Register.
+  fields:
+  - name: CTRENA
+    description: LIN Counter Enable. LIN counter will only count when enabled.
+    bit_offset: 0
+    bit_size: 1
+  - name: ZERONE
+    description: Zero on negative Edge of RXD. When enabled the counter is set to 0 and starts counting on a negative edge of RXD.
+    bit_offset: 1
+    bit_size: 1
+  - name: CNTRXLOW
+    description: Count while low Signal on RXD When counter is enabled and the signal on RXD is low, the counter increments.
+    bit_offset: 2
+    bit_size: 1
+  - name: LINC0CAP
+    description: Capture Counter on negative RXD Edge. When enabled the counter value is captured to LINC0 register on each negative RXD edge. A LINC0 interrupt is triggered when enabled.
+    bit_offset: 4
+    bit_size: 1
+  - name: LINC1CAP
+    description: Capture Counter on positive RXD Edge. When enabled the counter value is captured to LINC1 register on each positive RXD edge. A LINC1 interrupt is triggered when enabled.
+    bit_offset: 5
+    bit_size: 1
+  - name: LINC0_MATCH
+    description: Counter Compare Match Mode When this bit is set to 1 a counter compare match with LINC0 register triggers an LINC0 interrupt when enabled.
+    bit_offset: 6
+    bit_size: 1
+  - name: EN_FRM_ERR
+    description: Enable FRAME ERROR.
+    bit_offset: 7
+    bit_size: 1
+fieldset/PDBGCTL:
+  description: Peripheral Debug Control.
+  fields:
+  - name: FREE
+    description: Free run control.
+    bit_offset: 0
+    bit_size: 1
+  - name: SOFT
+    description: Soft halt boundary control. This function is only available, if [FREE] is set to 'STOP'.
+    bit_offset: 1
+    bit_size: 1
+    enum: SOFT
+fieldset/RXDATA:
+  description: UART Receive Data Register.
+  fields:
+  - name: DATA
+    description: Received Data. When read, this field contains the data that was received by the UART.
+    bit_offset: 0
+    bit_size: 8
+  - name: FRMERR
+    description: UART Framing Error Writing to this bit has no effect. The flag is cleared by writing 1 to the FRMERR bit in the UART EVENT ICLR register. This error is associated with the character at the top of the FIFO.
+    bit_offset: 8
+    bit_size: 1
+  - name: PARERR
+    description: UART Parity Error Writing to this bit has no effect. The flag is cleared by writing 1 to the PARERR bit in the UART EVENT ICLR register.
+    bit_offset: 9
+    bit_size: 1
+  - name: BRKERR
+    description: UART Break Error Writing to this bit has no effect. The flag is cleared by writing 1 to the BRKERR bit in the UART EVENT ICLR register. This error is associated with the character at the top of the FIFO. When a break occurs, only one 0 character is loaded into the FIFO. The next character is only enabled after the receive data input goes to a 1 (marking state) and the next valid start bit is received.
+    bit_offset: 10
+    bit_size: 1
+  - name: NERR
+    description: Noise Error. Writing to this bit has no effect. The flag is cleared by writing 1 to the NERR bit in the UART EVENT ICLR register.
+    bit_offset: 11
+    bit_size: 1
+fieldset/STAT:
+  description: UART Status Register.
+  fields:
+  - name: BUSY
+    description: UART Busy. This bit is set as soon as the transmit FIFO/buffer becomes non-empty (regardless of whether UART is enabled) or if a receive data is currently ongoing (after the start edge have been detected until a complete byte, including all stop bits, has been received by the shift register). In IDLE_Line mode the Busy signal also stays set during the idle time generation.
+    bit_offset: 0
+    bit_size: 1
+  - name: RXFE
+    description: UART Receive FIFO Empty.
+    bit_offset: 2
+    bit_size: 1
+  - name: RXFF
+    description: UART Receive FIFO Full.
+    bit_offset: 3
+    bit_size: 1
+  - name: RXCLR
+    description: RX FIFO Clear Status.
+    bit_offset: 4
+    bit_size: 1
+  - name: TXFE
+    description: UART Transmit FIFO Empty.
+    bit_offset: 5
+    bit_size: 1
+  - name: TXFF
+    description: UART Transmit FIFO Full The meaning of this bit depends on the state of the FEN bit in the CTL0 register.
+    bit_offset: 6
+    bit_size: 1
+  - name: TXCLR
+    description: TX FIFO Clear Status.
+    bit_offset: 7
+    bit_size: 1
+  - name: CTS
+    description: Clear To Send.
+    bit_offset: 8
+    bit_size: 1
+  - name: IDLE
+    description: IDLE mode has been detected in Idleline-Multiprocessor-Mode. The IDLE bit is used as an address tag for each block of characters. In idle-line multiprocessor format, this bit is set when a received character is an address.
+    bit_offset: 9
+    bit_size: 1
+  - name: SENDIDLE
+    description: TX FIFO Clear Status.
+    bit_offset: 10
+    bit_size: 1
+fieldset/TXDATA:
+  description: UART Transmit Data Register.
+  fields:
+  - name: DATA
+    description: Data Transmitted or Received Data that is to be transmitted via the UART is written to this field. When read, this field contains the data that was received by the UART.
+    bit_offset: 0
+    bit_size: 8
+enum/EPS:
+  bit_size: 1
+  variants:
+  - name: ODD
+    description: Odd parity is performed, which checks for an odd number of 1s.
+    value: 0
+  - name: EVEN
+    description: Even parity generation and checking is performed during transmission and reception, which checks for an even number of 1s in data and parity bits.
+    value: 1
+enum/HSE:
+  bit_size: 2
+  variants:
+  - name: OVS16
+    description: 16x oversampling.
+    value: 0
+  - name: OVS8
+    description: 8x oversampling.
+    value: 1
+  - name: OVS3
+    description: 3x oversampling. IrDA, Manchester and DALI not supported when 3x oversampling is enabled.
+    value: 2
+enum/IFLSSEL:
+  bit_size: 3
+  variants:
+  - name: ONE_FOURTH_ULP
+    description: RX FIFO >= 1/4 full, for ULP domain
+    value: 0
+  - name: ONE_FOURTH
+    description: RX FIFO >= 1/4 full or TX FIFO <= 1/4 full
+    value: 1
+  - name: HALF
+    description: RX FIFO >= 1/2 full or TX FIFO <= 1/2 full
+    value: 2
+  - name: THREE_FOURTH
+    description: RX FIFO >= 3/4 full or TX FIFO <= 3/4 full
+    value: 3
+  - name: FULL_ULP
+    description: RX FIFO is full, for ULP domain
+    value: 4
+  - name: FULL
+    description: RX or TX FIFO is full
+    value: 5
+  - name: AT_LEAST_ONE
+    description: RX or TX FIFO >= 1 entry available/free
+    value: 7
+enum/IRRXPL:
+  bit_size: 1
+  variants:
+  - name: HIGH
+    description: IrDA transceiver delivers a high pulse when a light pulse is seen.
+    value: 0
+  - name: LOW
+    description: IrDA transceiver delivers a low pulse when a light pulse is seen.
+    value: 1
+enum/IRTXCLK:
+  bit_size: 1
+  variants:
+  - name: BITCLK
+    description: IrDA encode data is based on the functional clock.
+    value: 0
+  - name: BRCLK
+    description: IrDA encode data is based on the Baud Rate clock< when select 8x oversampling, the IRTXPL cycle should less 8; when select 16x oversampling, the IRTXPL cycle should less 16.
+    value: 1
+enum/MODE:
+  bit_size: 3
+  variants:
+  - name: UART
+    description: Normal operation.
+    value: 0
+  - name: RS485
+    description: 'RS485 mode: UART needs to be IDLE with receiving data for the in EXTDIR_HOLD set time. EXTDIR_SETUP defines the time the RTS line is set to high before sending. When the buffer is empty the RTS line is set low again. A transmit will be delayed as long the UART is receiving data.'
+    value: 1
+  - name: IDLELINE
+    description: The UART operates in IDLE Line Mode.
+    value: 2
+  - name: ADDR9BIT
+    description: The UART operates in 9 Bit Address mode.
+    value: 3
+  - name: SMART
+    description: ISO7816 Smart Card Support The application must ensure that it sets 8-bit word length (WLEN set to 3h) and even parity (PEN set to 1, EPS set to 1, SPS set to 0) in UARTLCRH when using ISO7816 mode. The value of the STP2 bit in UARTLCRH is ignored and the number of stop bits is forced to 2.
+    value: 4
+  - name: DALI
+    description: DALI Mode:.
+    value: 5
+enum/SOFT:
+  bit_size: 1
+  variants:
+  - name: DEPRECATED
+    description: Not supported.
+    value: 0
+  - name: DELAYED
+    description: The peripheral blocks the debug freeze until it has reached a boundary where it can resume without corruption.
+    value: 1
+enum/STAT:
+  bit_size: 8
+  variants:
+  - name: NO_INTR
+    description: No interrupt pending.
+    value: 0
+  - name: RTFG
+    description: 'UART receive time-out interrupt; Interrupt Flag: RT; Interrupt Priority: Highest.'
+    value: 1
+  - name: FEFG
+    description: 'UART framing error interrupt; Interrupt Flag: FE.'
+    value: 2
+  - name: PEFG
+    description: 'UART parity error interrupt; Interrupt Flag: PE.'
+    value: 3
+  - name: BEFG
+    description: 'UART break error interrupt; Interrupt Flag: BE.'
+    value: 4
+  - name: OEFG
+    description: 'UART receive overrun error interrupt; Interrupt Flag: OE.'
+    value: 5
+  - name: RXNE
+    description: 'Negative edge on UARTxRXD interrupt; Interrupt Flag: RXNE.'
+    value: 6
+  - name: RXPE
+    description: 'Positive edge on UARTxRXD interrupt; Interrupt Flag: RXPE.'
+    value: 7
+  - name: LINC0
+    description: 'LIN capture 0 / match interrupt; Interrupt Flag: LINC0.'
+    value: 8
+  - name: LINC1
+    description: 'LIN capture 1 interrupt; Interrupt Flag: LINC1.'
+    value: 9
+  - name: LINOVF
+    description: 'LIN hardware counter overflow interrupt; Interrupt Flag: LINOVF.'
+    value: 10
+  - name: RXIFG
+    description: 'UART receive interrupt; Interrupt Flag: RX.'
+    value: 11
+  - name: TXIFG
+    description: 'UART transmit interrupt; Interrupt Flag: TX.'
+    value: 12
+  - name: EOT
+    description: 'UART end of transmission interrupt (transmit serializer empty); Interrupt Flag: EOT.'
+    value: 13
+  - name: ADDR_MATCH
+    description: '9-bit mode address match interrupt; Interrupt Flag: ADDR_MATCH.'
+    value: 14
+  - name: CTS
+    description: 'UART Clear to Send Modem interrupt; Interrupt Flag: CTS.'
+    value: 15
+  - name: DMA_DONE_RX
+    description: DMA DONE on RX.
+    value: 16
+  - name: DMA_DONE_TX
+    description: DMA DONE on TX.
+    value: 17
+  - name: NERR_EVT
+    description: Noise Error Event.
+    value: 18
+  - name: DMA_PREIRQ_RX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 19
+  - name: DMA_PREIRQ_TX
+    description: DMA PRE IRQ INTERRUPT.
+    value: 20
+  - name: LTFG
+    description: UART line time-out interrupt; Interrupt Flag.
+    value: 21
+enum/WLEN:
+  bit_size: 2
+  variants:
+  - name: DATABIT5
+    description: 5 bits (default).
+    value: 0
+  - name: DATABIT6
+    description: 6 bits.
+    value: 1
+  - name: DATABIT7
+    description: 7 bits.
+    value: 2
+  - name: DATABIT8
+    description: 8 bits.
+    value: 3

--- a/data/registers/unicommuart_v1.yaml
+++ b/data/registers/unicommuart_v1.yaml
@@ -242,14 +242,13 @@ fieldset/CPU_INT:
     description: Enable Positive Edge on UARTxRXD Interrupt.
     bit_offset: 6
     bit_size: 1
-  - name: LINC0
-    description: Enable LIN Capture 0 / Match Interrupt.
+  - name: LINC
+    description: 'LIN capture interrupt. Index 0 is the capture-or-match interrupt on the falling RXD edge, index 1 the capture interrupt on the rising edge.'
     bit_offset: 7
     bit_size: 1
-  - name: LINC1
-    description: Enable LIN Capture 1 Interrupt.
-    bit_offset: 8
-    bit_size: 1
+    array:
+      len: 2
+      stride: 1
   - name: LINOVF
     description: Enable LIN Hardware Counter Overflow Interrupt.
     bit_offset: 9

--- a/data/registers/unicommuart_v1.yaml
+++ b/data/registers/unicommuart_v1.yaml
@@ -28,7 +28,7 @@ block/CPU_INT:
     description: Interrupt clear.
     byte_offset: 40
     access: Write
-    fieldset: ICLR
+    fieldset: CPU_INT
 block/DMA_TRIG_RX:
   items:
   - name: IMASK
@@ -156,13 +156,12 @@ block/UNICOMMUART:
     description: UART LIN Mode Control Register.
     byte_offset: 4404
     fieldset: LINCTL
-  - name: LINC0
+  - name: LINC
     description: UART LIN Mode Capture 0 Register.
+    array:
+      len: 2
+      stride: 4
     byte_offset: 4408
-    fieldset: LINC
-  - name: LINC1
-    description: UART LIN Mode Capture 1 Register.
-    byte_offset: 4412
     fieldset: LINC
   - name: IRCTL
     description: eUSCI_Ax IrDA Control Word Register.
@@ -391,85 +390,6 @@ fieldset/IBRD:
     description: Integer Baud-Rate Divisor.
     bit_offset: 0
     bit_size: 16
-fieldset/ICLR:
-  description: Interrupt clear.
-  fields:
-  - name: RTOUT
-    description: Clear UARTOUT Receive Time-Out Interrupt.
-    bit_offset: 0
-    bit_size: 1
-  - name: FRMERR
-    description: Clear UART Framing Error Interrupt.
-    bit_offset: 1
-    bit_size: 1
-  - name: PARERR
-    description: Clear UART Parity Error Interrupt.
-    bit_offset: 2
-    bit_size: 1
-  - name: BRKERR
-    description: Clear UART Break Error Interrupt.
-    bit_offset: 3
-    bit_size: 1
-  - name: OVRERR
-    description: Clear UART Receive Overrun Error Interrupt.
-    bit_offset: 4
-    bit_size: 1
-  - name: RXNE
-    description: Clear Negative Edge on UARTxRXD Interrupt.
-    bit_offset: 5
-    bit_size: 1
-  - name: RXPE
-    description: Clear Positive Edge on UARTxRXD Interrupt.
-    bit_offset: 6
-    bit_size: 1
-  - name: LINC0
-    description: Clear LIN Capture 0 / Match Interrupt.
-    bit_offset: 7
-    bit_size: 1
-  - name: LINC1
-    description: Clear LIN Capture 1 Interrupt.
-    bit_offset: 8
-    bit_size: 1
-  - name: LINOVF
-    description: Clear LIN Hardware Counter Overflow Interrupt.
-    bit_offset: 9
-    bit_size: 1
-  - name: RXINT
-    description: Clear UART Receive Interrupt.
-    bit_offset: 10
-    bit_size: 1
-  - name: TXINT
-    description: Clear UART Transmit Interrupt.
-    bit_offset: 11
-    bit_size: 1
-  - name: EOT
-    description: Clear UART End of Transmission Interrupt Indicates that the last bit of all transmitted data and flags has left the serializer and without any further Data in the TX Fifo or Buffer.
-    bit_offset: 12
-    bit_size: 1
-  - name: ADDR_MATCH
-    description: Clear Address Match Interrupt.
-    bit_offset: 13
-    bit_size: 1
-  - name: CTS
-    description: Clear UART Clear to Send Modem Interrupt.
-    bit_offset: 14
-    bit_size: 1
-  - name: DMA_DONE_RX
-    description: Clear DMA Done on RX Event Channel Interrupt.
-    bit_offset: 15
-    bit_size: 1
-  - name: DMA_DONE_TX
-    description: Clear DMA Done on TX Event Channel Interrupt.
-    bit_offset: 16
-    bit_size: 1
-  - name: NERR
-    description: Noise Error on triple voting. Asserted when the 3 samples of majority voting are not equal.
-    bit_offset: 17
-    bit_size: 1
-  - name: LTOUT
-    description: Clear UARTOUT Line Time-Out Interrupt.
-    bit_offset: 20
-    bit_size: 1
 fieldset/IFLS:
   description: UART Interrupt FIFO Level Select Register.
   fields:

--- a/data/registers/vref_v1.yaml
+++ b/data/registers/vref_v1.yaml
@@ -66,7 +66,7 @@ fieldset/CTL0:
   description: Control 0.
   fields:
   - name: ENABLE
-    description: Enables the corresponding VREF reference buffer. A device may implement fewer buffers than the three the register can address; the device datasheet says how many.
+    description: 'Enables reference buffer n. Each buffer feeds a different set of on-chip analog consumers rather than being interchangeable: hw_vref.h names buffer 1 COMP_VREF and buffer 2 ADC_VREF, and index 0 is the one TI''s own driverlib enables. SLAU846 Figure 23-1 is a superset diagram, so a device need not implement all three; nothing published says which it has.'
     bit_offset: 0
     bit_size: 1
     array:
@@ -85,9 +85,11 @@ fieldset/CTL1:
   description: Control 1.
   fields:
   - name: READY
-    description: VREF output is ready. Once set, it stays set when VREF is disabled and later re-enabled. On a device with more than one reference buffer it only applies to the first one enabled.
+    description: 'Reference buffer n has settled. One bit per ENABLE, but not at the same offsets: READY0 is bit 0, READY1 bit 2 and READY2 bit 3, with bit 1 unused. Beware VREF_ERR_01, which leaves the bit set once the buffer has been enabled a first time since reset, so on an affected device it cannot report a later enable and the datasheet startup time is the only signal.'
     bit_offset: 0
     bit_size: 1
+    array:
+      offsets: [0, 2, 3]
 fieldset/CTL2:
   description: Control 2.
   fields:

--- a/data/registers/vref_v1.yaml
+++ b/data/registers/vref_v1.yaml
@@ -1,0 +1,155 @@
+block/GPRCM:
+  items:
+  - name: PWREN
+    description: Power enable.
+    byte_offset: 0
+    fieldset: PWREN
+  - name: RSTCTL
+    description: Reset Control.
+    byte_offset: 4
+    access: Write
+    fieldset: RSTCTL
+  - name: STAT
+    description: Status Register.
+    byte_offset: 20
+    access: Read
+    fieldset: STAT
+block/VREF:
+  description: PERIPHERALREGION.
+  items:
+  - name: GPRCM
+    byte_offset: 2048
+    block: GPRCM
+  - name: CLKDIV
+    description: Clock Divider.
+    byte_offset: 4096
+    fieldset: CLKDIV
+  - name: CLKSEL
+    description: Clock Selection.
+    byte_offset: 4104
+    fieldset: CLKSEL
+  - name: CTL0
+    description: Control 0.
+    byte_offset: 4352
+    fieldset: CTL0
+  - name: CTL1
+    description: Control 1.
+    byte_offset: 4356
+    fieldset: CTL1
+  - name: CTL2
+    description: Control 2.
+    byte_offset: 4360
+    fieldset: CTL2
+fieldset/CLKDIV:
+  description: Clock Divider.
+  fields:
+  - name: RATIO
+    description: Selects divide ratio of module clock to be used in sample and hold logic.
+    bit_offset: 0
+    bit_size: 3
+fieldset/CLKSEL:
+  description: Clock Selection.
+  fields:
+  - name: LFCLK_SEL
+    description: Selects LFCLK as clock source if enabled.
+    bit_offset: 1
+    bit_size: 1
+  - name: MFCLK_SEL
+    description: Selects MFCLK as clock source if enabled.
+    bit_offset: 2
+    bit_size: 1
+  - name: BUSCLK_SEL
+    description: Selects BUSCLK as clock source if enabled.
+    bit_offset: 3
+    bit_size: 1
+fieldset/CTL0:
+  description: Control 0.
+  fields:
+  - name: ENABLE
+    description: Enables the corresponding VREF reference buffer. A device may implement fewer buffers than the three the register can address; the device datasheet says how many.
+    bit_offset: 0
+    bit_size: 1
+    array:
+      len: 3
+      stride: 1
+  - name: BUFCONFIG
+    description: Selects the output voltage of the reference buffers. Changing from 2.5V to 1.4V has a very slow slew rate and READY stays set throughout, so that transition has to be timed by the caller.
+    bit_offset: 7
+    bit_size: 1
+    enum: BUFCONFIG
+  - name: SHMODE
+    description: This bit enable sample and hold mode.
+    bit_offset: 8
+    bit_size: 1
+fieldset/CTL1:
+  description: Control 1.
+  fields:
+  - name: READY
+    description: VREF output is ready. Once set, it stays set when VREF is disabled and later re-enabled. On a device with more than one reference buffer it only applies to the first one enabled.
+    bit_offset: 0
+    bit_size: 1
+fieldset/CTL2:
+  description: Control 2.
+  fields:
+  - name: SHCYCLE
+    description: Sample and Hold cycle count Total cycles of module clock for sample and hold phase when VREF is working in sample and hold mode in STANDBY to save power. This field should be greater than HCYCLE field. The difference between this field and HCYCLE gives the number of cycles of sample phase. Please refer VREF section of datasheet for recommended values of sample and hold times.
+    bit_offset: 0
+    bit_size: 16
+  - name: HCYCLE
+    description: Hold cycle count Total cycles of module clock for hold phase when VREF is working in sample and hold mode in STANDBY to save power. Please refer VREF section of datasheet for recommended values of sample and hold times.
+    bit_offset: 16
+    bit_size: 16
+fieldset/PWREN:
+  description: Power enable.
+  fields:
+  - name: ENABLE
+    description: Enable the power.
+    bit_offset: 0
+    bit_size: 1
+  - name: KEY
+    description: KEY to allow Power State Change.
+    bit_offset: 24
+    bit_size: 8
+    enum: PWREN_KEY
+fieldset/RSTCTL:
+  description: Reset Control.
+  fields:
+  - name: RESETASSERT
+    description: Assert reset to the peripheral.
+    bit_offset: 0
+    bit_size: 1
+  - name: RESETSTKYCLR
+    description: Clear the RESETSTKY bit in the STAT register.
+    bit_offset: 1
+    bit_size: 1
+  - name: KEY
+    description: Unlock key.
+    bit_offset: 24
+    bit_size: 8
+    enum: RESET_KEY
+fieldset/STAT:
+  description: Status Register.
+  fields:
+  - name: RESETSTKY
+    description: This bit indicates, if the peripheral was reset, since this bit was cleared by RESETSTKYCLR in the RSTCTL register.
+    bit_offset: 16
+    bit_size: 1
+enum/BUFCONFIG:
+  bit_size: 1
+  variants:
+  - name: OUTPUT2P5V
+    description: Configure Output Buffer to 2.5v.
+    value: 0
+  - name: OUTPUT1P4V
+    description: Configure Output Buffer to 1.4v.
+    value: 1
+enum/PWREN_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 38
+enum/RESET_KEY:
+  bit_size: 8
+  variants:
+  - name: KEY
+    value: 177

--- a/data/registers/wwdt_v1.yaml
+++ b/data/registers/wwdt_v1.yaml
@@ -73,19 +73,19 @@ block/WWDT:
     byte_offset: 4348
     access: Read
     fieldset: DESC
-  - name: WWDTCTL0
+  - name: CTL0
     description: Window Watchdog Timer Control Register 0.
     byte_offset: 4352
     fieldset: WWDTCTL0
-  - name: WWDTCTL1
+  - name: CTL1
     description: Window Watchdog Timer Control Register 0.
     byte_offset: 4356
     fieldset: WWDTCTL1
-  - name: WWDTCNTRST
+  - name: CNTRST
     description: Window Watchdog Timer Counter Reset Register.
     byte_offset: 4360
     fieldset: WWDTCNTRST
-  - name: WWDTSTAT
+  - name: STAT
     description: Window Watchdog Timer Status Register.
     byte_offset: 4364
     access: Read
@@ -198,15 +198,13 @@ fieldset/WWDTCTL0:
     bit_offset: 4
     bit_size: 3
     enum: PER
-  - name: WINDOW0
-    description: Closed window period in percentage of the timer interval. WWDTCTL1.WINSEL determines the active window setting (WWDTCTL0.WINDOW0 or WWDTCTL0.WINDOW1).
+  - name: WINDOW
+    description: Closed window period in percentage of the timer interval. CTL1.WINSEL picks which of the two is active.
     bit_offset: 8
     bit_size: 3
-    enum: WINDOW
-  - name: WINDOW1
-    description: Closed window period in percentage of the timer interval. WWDTCTL1.WINSEL determines the active window setting (WWDTCTL0.WINDOW0 or WWDTCTL0.WINDOW1).
-    bit_offset: 12
-    bit_size: 3
+    array:
+      len: 2
+      stride: 4
     enum: WINDOW
   - name: MODE
     description: Window Watchdog Timer Mode.

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -695,8 +695,16 @@ fn get_peripheral_type_version(chip_name: &str, name: &str) -> (PeripheralType, 
     } else {
         PeripheralType::Unknown
     };
+
+    // TIMB is a basic timer and has its own register block, so the key names the instance kind
+    // rather than the peripheral type. TIMA and TIMG share one, and both keep the plain `tim` key.
+    let key = if ty == PeripheralType::Tim && name.starts_with("TIMB") {
+        "timb"
+    } else {
+        &ty.to_string()
+    };
     let version = PERIMAP
-        .get(&format!("{}:{}", chip_name, ty))
+        .get(&format!("{}:{}", chip_name, key))
         .map(|s| s.to_string());
 
     (ty, version)

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -606,6 +606,45 @@ fn generate_missing(
         }
     }
 
+    // The beeper is documented as one SYSCTL register and addressed through it, so sysconfig does
+    // not list it and its register block was carved out of the SYSCTL maps. Every family below
+    // puts BEEPCFG at 0x1190 with the same two fields, per its hw_sysctl_*.h.
+    //
+    // Keyed on the family and not on the SYSCTL version: mspm0l112x and mspm0l211x have the beeper
+    // and share `sysctl_l122x_l222x` with mspm0l122x and mspm0l222x, which do not.
+    const BEEPER_FAMILIES: &[&str] = &[
+        "mspm0c110x",
+        "mspm0c1105_c1106",
+        "msps003fx",
+        "mspm0h321x",
+        "mspm0l112x",
+        "mspm0l211x",
+    ];
+
+    if BEEPER_FAMILIES.contains(&chip_name) {
+        let address = get_peripheral_addresses(chip_name, "SYSCTL", header, sysconfig)?
+            .context(format!("{chip_name}: BEEPER needs SYSCTL's address"))?;
+
+        let version = PERIMAP
+            .get(&format!("{}:{}", chip_name, PeripheralType::Beeper))
+            .map(|s| s.to_string());
+
+        peripherals.insert(
+            "BEEPER".to_string(),
+            Peripheral {
+                name: "BEEPER".to_string(),
+                ty: PeripheralType::Beeper,
+                version,
+                address: Some(address),
+                // It is part of SYSCTL, which is in PD0 on every family that has a beeper.
+                power_domain: PowerDomain::Pd0,
+                pins: vec![],
+                sys_fentries: None,
+                unicomm: None,
+            },
+        );
+    }
+
     Ok(())
 }
 

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -64,10 +64,11 @@ fn generate_family(
     // Data shared across all chips in a family.
     let packages = get_packages(&family.family, sysconfig)?;
     let iomux = generate_pincm(&family.family, sysconfig)?;
-    let peripherals = generate_peripherals2(&family.family, header, sysconfig)?;
+    let mut peripherals = generate_peripherals2(&family.family, header, sysconfig)?;
     let interrupts = generate_irqs(&family.family, header, int_groups)?;
     let dma_channels = generate_dma_channels(&family.family, sysconfig)?;
     let adc_memctl = generate_adc_memctl_dim(&family.family, sysconfig)?;
+    apply_unicomm(family, header, &mut peripherals)?;
 
     for part_number in family.part_numbers.iter() {
         // Filter for package types available on the part number.
@@ -279,6 +280,7 @@ fn generate_peripherals2(
                 power_domain,
                 pins: vec![],
                 sys_fentries,
+                unicomm: None,
             };
 
             // Lookup the pins
@@ -527,6 +529,7 @@ fn generate_missing(
             power_domain: PowerDomain::Pd1,
             pins: vec![],
             sys_fentries: None,
+            unicomm: None,
         },
     );
 
@@ -550,6 +553,7 @@ fn generate_missing(
             power_domain: PowerDomain::Pd1,
             pins: vec![],
             sys_fentries: None,
+            unicomm: None,
         },
     );
 
@@ -581,6 +585,7 @@ fn generate_missing(
                     power_domain: PowerDomain::Pd0,
                     pins: vec![],
                     sys_fentries: None,
+                    unicomm: None,
                 });
 
             let pin = device_pin
@@ -899,6 +904,64 @@ fn generate_adc_memctl_dim(chip_name: &str, sysconfig: &SysconfigFile) -> anyhow
         chip_name
     );
     Ok(result.unwrap())
+}
+
+/// Offset of each UNICOMM register map below the instance's own address.
+///
+/// Fixed by the IP: `mspm0g518x.h` computes them with `UC_UART_BASE(UC0_BASE)` and friends over
+/// `UC_*_OFFSET`, and the L-series headers write every base out literally. `apply_unicomm` checks
+/// each literal against these.
+const UNICOMM_MODE_OFFSETS: &[(&str, u32)] = &[
+    ("UART", 0x80000),
+    ("I2CC", 0x60000),
+    ("I2CT", 0x40000),
+    ("SPI", 0x20000),
+];
+
+/// Record which register maps each UNICOMM instance implements.
+fn apply_unicomm(
+    family: &PartFamily,
+    header: &Header,
+    peripherals: &mut BTreeMap<String, Peripheral>,
+) -> anyhow::Result<()> {
+    for (name, peripheral) in peripherals.iter_mut() {
+        if peripheral.ty != PeripheralType::Unicomm {
+            continue;
+        }
+
+        let modes = header.unicomm_modes.get(name).context(format!(
+            "{}: {name} is not in the header's UNICOMM instance table",
+            family.family
+        ))?;
+
+        ensure!(
+            modes.uart || modes.i2c_controller || modes.i2c_target || modes.spi,
+            "{}: {name} implements no UNICOMM register map",
+            family.family
+        );
+
+        // Where the header states a map's address rather than computing it, hold it to the offset
+        // a consumer is told to use. A part which moved one would otherwise be silently wrong.
+        if let Some(address) = peripheral.address {
+            for (mode, offset) in UNICOMM_MODE_OFFSETS {
+                let Some(&stated) = header.peripheral_addresses.get(&format!("{name}_{mode}"))
+                else {
+                    continue;
+                };
+
+                ensure!(
+                    stated == address - offset,
+                    "{}: {name}_{mode} is at {stated:#x}, not {:#x} as the offset from {name} says",
+                    family.family,
+                    address - offset
+                );
+            }
+        }
+
+        peripheral.unicomm = Some(*modes);
+    }
+
+    Ok(())
 }
 
 fn adc_vrsel_mapping(vrsel: &String) -> anyhow::Result<u8> {

--- a/mspm0-data-gen/src/generate.rs
+++ b/mspm0-data-gen/src/generate.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{anyhow, bail, ensure, Context};
 use mspm0_data_types::{
     Chip, DmaChannel, Interrupt, Memory, Package, PackagePin, Peripheral, PeripheralPin,
-    PeripheralType, PowerDomain,
+    PeripheralType, PowerDomain, Unicomm,
 };
 use regex::Regex;
 
@@ -918,6 +918,14 @@ const UNICOMM_MODE_OFFSETS: &[(&str, u32)] = &[
     ("SPI", 0x20000),
 ];
 
+/// The register map each UNICOMM mode is described by, and how [`Unicomm`] reports it.
+const UNICOMM_MODE_TYPES: &[(&str, PeripheralType, fn(&Unicomm) -> bool)] = &[
+    ("UART", PeripheralType::UnicommUart, |m| m.uart),
+    ("I2CC", PeripheralType::UnicommI2cc, |m| m.i2c_controller),
+    ("I2CT", PeripheralType::UnicommI2ct, |m| m.i2c_target),
+    ("SPI", PeripheralType::UnicommSpi, |m| m.spi),
+];
+
 /// Record which register maps each UNICOMM instance implements.
 fn apply_unicomm(
     family: &PartFamily,
@@ -959,6 +967,52 @@ fn apply_unicomm(
         }
 
         peripheral.unicomm = Some(*modes);
+    }
+
+    // Each mode the instance implements becomes a peripheral of its own, so that a consumer gets
+    // the right register block at the right address rather than having to subtract an offset from
+    // the instance. TI's own SVDs model them this way too, as UC0_UART, UC0_I2CC and so on.
+    //
+    // The instance is what the device has: it owns the pins, the interrupt and the low power
+    // facts, and the views repeat only what is true of them as a window onto the same silicon.
+    let mut views = Vec::new();
+
+    for peripheral in peripherals.values() {
+        let (Some(modes), Some(address)) = (peripheral.unicomm, peripheral.address) else {
+            continue;
+        };
+
+        for (mode, ty, implemented) in UNICOMM_MODE_TYPES {
+            if !implemented(&modes) {
+                continue;
+            }
+
+            let offset = UNICOMM_MODE_OFFSETS
+                .iter()
+                .find(|(name, _)| name == mode)
+                .map(|(_, offset)| offset)
+                .expect("every mode has an offset");
+
+            let name = format!("{}_{mode}", peripheral.name);
+            let version = PERIMAP
+                .get(&format!("{}:{ty}", family.family))
+                .map(|version| version.to_string());
+
+            views.push(Peripheral {
+                name: name.clone(),
+                ty: *ty,
+                version,
+                address: Some(address - offset),
+                power_domain: peripheral.power_domain,
+                pins: vec![],
+                sys_fentries: None,
+                unicomm: None,
+            });
+        }
+    }
+
+    for view in views {
+        peripherals.insert(view.name.clone(), view);
     }
 
     Ok(())

--- a/mspm0-data-gen/src/header.rs
+++ b/mspm0-data-gen/src/header.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, fs, path::Path, sync::LazyLock};
 
 use anyhow::Context;
+use mspm0_data_types::Unicomm;
 use regex::Regex;
 
 #[derive(Debug)]
@@ -38,6 +39,9 @@ impl Headers {
 pub struct Header {
     pub peripheral_addresses: BTreeMap<String, u32>,
 
+    /// Which register maps each UNICOMM instance implements, keyed by instance name.
+    pub unicomm_modes: BTreeMap<String, Unicomm>,
+
     pub irq_numbers: BTreeMap<i32, Vec<String>>,
     // TODO: flash info
     // TODO: Available IOMUX indices
@@ -54,11 +58,53 @@ impl Header {
         // The Cortex-M0 only has 32 IRQs. This means that "interrupt groups" need to be resolved
         // for truly handling IRQs.
         let irq_numbers = Self::get_irq_numbers(chip_name, &content)?;
+        let unicomm_modes = Self::get_unicomm_modes(&content);
 
         Ok(Self {
             peripheral_addresses,
+            unicomm_modes,
             irq_numbers,
         })
+    }
+
+    /// Read which register maps each UNICOMM instance implements.
+    ///
+    /// A UNICOMM instance is a UART, an SPI, an I2C controller or an I2C target depending on
+    /// `IPMODE.SELECT`, but no instance implements all four. The header's own instance table is the
+    /// only source which says which: it initializes a pointer per map the instance has and leaves
+    /// the rest null.
+    ///
+    /// ```c,no_run
+    /// static const UNICOMM_Inst_Regs UC4_Inst = {
+    ///     .inst      = (UNICOMM_Regs *) UC4_BASE,
+    ///     .uart      = (UNICOMMUART_Regs *) UC4_UART_BASE,
+    ///     .spi       = (UNICOMMSPI_Regs *) UC4_SPI_BASE,
+    ///     .fixedMode = false
+    /// };
+    /// ```
+    ///
+    /// `fixedMode` is not read: it is true exactly when one map is initialized, which the maps
+    /// themselves already say.
+    fn get_unicomm_modes(content: &str) -> BTreeMap<String, Unicomm> {
+        static INSTANCE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"(?s)UNICOMM_Inst_Regs\s+(?<instance>\w+)_Inst\s*=\s*\{(?<body>[^}]*)\}")
+                .unwrap()
+        });
+
+        INSTANCE
+            .captures_iter(content)
+            .map(|capture| {
+                let body = &capture["body"];
+                let modes = Unicomm {
+                    uart: body.contains(".uart"),
+                    i2c_controller: body.contains(".i2cc"),
+                    i2c_target: body.contains(".i2ct"),
+                    spi: body.contains(".spi"),
+                };
+
+                (capture["instance"].to_string(), modes)
+            })
+            .collect()
     }
 
     fn get_peripheral_addresses(

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -26,6 +26,7 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     // The mode maps of a UNICOMM instance. The SVDs describe them per instance and identically, so
     // one version each covers the portfolio, as with the wrapper.
     (".*:unicommi2cc", "v1"),
+    (".*:unicommuart", "v1"),
     // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight
     // registers with the same fields, so every family shares one version. The SVDs disagree with
     // the TRMs and with each other about CTL0 bits 1 and 2, which the YAML resolves in the TRMs'

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -26,6 +26,7 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     // The mode maps of a UNICOMM instance. The SVDs describe them per instance and identically, so
     // one version each covers the portfolio, as with the wrapper.
     (".*:unicommi2cc", "v1"),
+    (".*:unicommspi", "v1"),
     (".*:unicommuart", "v1"),
     // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight
     // registers with the same fields, so every family shares one version. The SVDs disagree with

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -20,6 +20,26 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:flashctl", "v1"),
     (".*:trng", "v1"),
     (".*:canfd", "v1"),
+    // One layout, but DACOUTEN (CTL1 bit 11) only exists where the header states
+    // `COMP_SYS_DACOUT_EN`: the 8-bit reference DAC reaches a pin on these four families only.
+    ("mspm0c1105_c1106:comp", "dacout"),
+    ("mspm0g518x:comp", "dacout"),
+    ("mspm0l112x:comp", "dacout"),
+    ("mspm0l211x:comp", "dacout"),
+    (".*:comp", "v1"),
+    // Three CRC generators. `16` lacks CRCCTRL.POLYSIZE: those devices are CRC-16 only, stated
+    // per device by the headers' `CRC_SYS_CRC32_ENABLE = 0`. `p` adds the programmable-polynomial
+    // CRCPOLY register; TI types those instances `CRCP_Regs` and the TRMs call them CRCP0.
+    ("mspm0c110x:crc", "16"),
+    ("msps003fx:crc", "16"),
+    ("mspm0c1105_c1106:crc", "16"),
+    ("mspm0h321x:crc", "16"),
+    ("mspm0l112x:crc", "16"),
+    ("mspm0l211x:crc", "16"),
+    ("mspm0g..1x:crc", "p"),
+    ("mspm0g518x:crc", "p"),
+    ("mspm0l.22x:crc", "p"),
+    (".*:crc", "v1"),
     // One version: the SDK ships a single hw_unicomm.h for the portfolio, and the wrapper is what
     // every instance has regardless of which mode maps it implements.
     (".*:unicomm", "v1"),

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -26,6 +26,7 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     // The mode maps of a UNICOMM instance. The SVDs describe them per instance and identically, so
     // one version each covers the portfolio, as with the wrapper.
     (".*:unicommi2cc", "v1"),
+    (".*:unicommi2ct", "v1"),
     (".*:unicommspi", "v1"),
     (".*:unicommuart", "v1"),
     // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -23,6 +23,9 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     // One version: the SDK ships a single hw_unicomm.h for the portfolio, and the wrapper is what
     // every instance has regardless of which mode maps it implements.
     (".*:unicomm", "v1"),
+    // The mode maps of a UNICOMM instance. The SVDs describe them per instance and identically, so
+    // one version each covers the portfolio, as with the wrapper.
+    (".*:unicommi2cc", "v1"),
     // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight
     // registers with the same fields, so every family shares one version. The SVDs disagree with
     // the TRMs and with each other about CTL0 bits 1 and 2, which the YAML resolves in the TRMs'

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -10,6 +10,10 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:iomux", "v1"),
     (".*:mathacl", "v1"),
     (".*:opa", "v1"),
+    // A TIMB instance is a basic timer: its counters live at 0x1100 where the general-purpose
+    // block has CCPD/ODIS/CCLKCTL, and it has neither CLKDIV/CLKSEL nor a COUNTERREGS group.
+    // Keyed on the instance kind, not the peripheral type — see `get_peripheral_type_version`.
+    (".*:timb", "btimer"),
     (".*:tim", "v1"),
     (".*:adc", "v1"),
     (".*:wwdt", "v1"),

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -16,6 +16,11 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:flashctl", "v1"),
     (".*:trng", "v1"),
     (".*:canfd", "v1"),
+    // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight
+    // registers with the same fields, so every family shares one version. The SVDs disagree with
+    // the TRMs and with each other about CTL0 bits 1 and 2, which the YAML resolves in the TRMs'
+    // favour.
+    (".*:vref", "v1"),
     (".*:factoryregion", "v1"),
     // SLAU893 describes two C-series SYSCTLs, "SYSCTL_C1103_C1104" and "SYSCTL_C1105_C1106". The
     // latter is a superset: it adds the HFXT and LFXT crystal drivers, `MCLKCFG.FLASHWAIT` and the

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -17,8 +17,11 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:trng", "v1"),
     (".*:canfd", "v1"),
     (".*:factoryregion", "v1"),
+    // SLAU893 describes two C-series SYSCTLs, "SYSCTL_C1103_C1104" and "SYSCTL_C1105_C1106". The
+    // latter is a superset: it adds the HFXT and LFXT crystal drivers, `MCLKCFG.FLASHWAIT` and the
+    // HSCLK mux, which its datasheet also specifies and MSPM0C1104's does not.
     ("mspm0c110x:sysctl", "c110x"),
-    ("mspm0c1105_c1106:sysctl", "c110x"),
+    ("mspm0c1105_c1106:sysctl", "c1105_c1106"),
     ("msps003fx:sysctl", "c110x"),
     ("mspm0g..0x:sysctl", "g350x_g310x_g150x_g110x"),
     ("mspm0g..1x:sysctl", "g351x_g151x"),

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -20,6 +20,9 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     (".*:flashctl", "v1"),
     (".*:trng", "v1"),
     (".*:canfd", "v1"),
+    // One version: the SDK ships a single hw_unicomm.h for the portfolio, and the wrapper is what
+    // every instance has regardless of which mode maps it implements.
+    (".*:unicomm", "v1"),
     // SLAU846 §23.3, SLAU847 §19.3, SLAU893 §13.3 and SLAU923 §11.3 describe the same eight
     // registers with the same fields, so every family shares one version. The SVDs disagree with
     // the TRMs and with each other about CTL0 bits 1 and 2, which the YAML resolves in the TRMs'

--- a/mspm0-data-gen/src/perimap.rs
+++ b/mspm0-data-gen/src/perimap.rs
@@ -43,8 +43,10 @@ pub static PERIMAP: RegexMap<&str> = RegexMap::new(&[
     ("msps003fx:sysctl", "c110x"),
     ("mspm0g..0x:sysctl", "g350x_g310x_g150x_g110x"),
     ("mspm0g..1x:sysctl", "g351x_g151x"),
-    // FIXME: When reference manual is updated for G511x/G518x, update this if needed.
-    ("mspm0g5..x:sysctl", "g350x_g310x_g150x_g110x"),
+    // Derived from the G351x block: same flash-protection and security region, minus the SRAM
+    // bank-1 registers and CANCLKSRC, plus the USB FLL. TI's own header and SVD for the family
+    // describe it; only the TRM still lags.
+    ("mspm0g518x:sysctl", "g518x"),
     ("mspm0h321x:sysctl", "h321x"),
     ("mspm0l..0x:sysctl", "l110x_l130x_l134x"),
     ("mspm0l134x:sysctl", "l110x_l130x_l134x"),

--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -165,6 +165,18 @@ pub enum PeripheralType {
 
     Unicomm,
 
+    /// The UART register map of a UNICOMM instance, at a fixed offset below it.
+    UnicommUart,
+
+    /// The I2C controller register map of a UNICOMM instance, at a fixed offset below it.
+    UnicommI2cc,
+
+    /// The I2C target register map of a UNICOMM instance, at a fixed offset below it.
+    UnicommI2ct,
+
+    /// The SPI register map of a UNICOMM instance, at a fixed offset below it.
+    UnicommSpi,
+
     Usbfs,
 
     Vref,
@@ -210,6 +222,10 @@ impl fmt::Display for PeripheralType {
             PeripheralType::Trng => "trng",
             PeripheralType::Uart => "uart",
             PeripheralType::Unicomm => "unicomm",
+            PeripheralType::UnicommUart => "unicommuart",
+            PeripheralType::UnicommI2cc => "unicommi2cc",
+            PeripheralType::UnicommI2ct => "unicommi2ct",
+            PeripheralType::UnicommSpi => "unicommspi",
             PeripheralType::Usbfs => "usbfs",
             PeripheralType::Vref => "vref",
             PeripheralType::Wuc => "wuc",

--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -251,6 +251,40 @@ pub struct Peripheral {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sys_fentries: Option<usize>,
+
+    /// Which register maps this UNICOMM instance implements.
+    ///
+    /// `None` for peripherals which are not UNICOMM instances.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unicomm: Option<Unicomm>,
+}
+
+/// Which register maps a UNICOMM instance implements.
+///
+/// UNICOMM is one peripheral which is a UART, an SPI, an I2C controller or an I2C target depending
+/// on `IPMODE.SELECT`, with a register map per mode at a fixed offset below the instance's own
+/// address. **No instance implements all four**, and which it implements does not follow the
+/// instance name: on MSPM0G518x `UC0` is a UART or either half of an I2C but never an SPI, `UC2` is
+/// an SPI only, and `UC3` is a UART or an SPI.
+///
+/// An instance with one mode has nothing to select and no `IPMODE` register to select it with, so
+/// writing `IPMODE` is only meaningful where more than one of these is true.
+///
+/// Read from the instance table in the SDK's device header, which populates a register pointer per
+/// mode the instance has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Unicomm {
+    /// Implements the UART register map, `0x80000` below the instance address.
+    pub uart: bool,
+
+    /// Implements the I2C controller register map, `0x60000` below the instance address.
+    pub i2c_controller: bool,
+
+    /// Implements the I2C target register map, `0x40000` below the instance address.
+    pub i2c_target: bool,
+
+    /// Implements the SPI register map, `0x20000` below the instance address.
+    pub spi: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mspm0-data-types/src/lib.rs
+++ b/mspm0-data-types/src/lib.rs
@@ -99,6 +99,12 @@ pub enum PeripheralType {
 
     AesAdv,
 
+    /// The beeper, a square wave output driven from LFCLK.
+    ///
+    /// Documented as part of SYSCTL and addressed through it, but described here as a peripheral of
+    /// its own so it gets a register block rather than four registers' worth of SYSCTL variants.
+    Beeper,
+
     Aes,
 
     Canfd,
@@ -193,6 +199,7 @@ impl fmt::Display for PeripheralType {
             PeripheralType::Adc => "adc",
             PeripheralType::Aes => "aes",
             PeripheralType::AesAdv => "aesadv",
+            PeripheralType::Beeper => "beeper",
             PeripheralType::Canfd => "canfd",
             PeripheralType::Comp => "comp",
             PeripheralType::Cpuss => "cpuss",

--- a/mspm0-metapac-gen/res/metadata.rs
+++ b/mspm0-metapac-gen/res/metadata.rs
@@ -21,6 +21,36 @@ pub struct Peripheral {
     pub pins: &'static [PeripheralPin],
     pub power_domain: PowerDomain,
     pub sys_fentries: Option<usize>,
+
+    /// Which register maps this UNICOMM instance implements.
+    ///
+    /// `None` for peripherals which are not UNICOMM instances.
+    pub unicomm: Option<Unicomm>,
+}
+
+/// Which register maps a UNICOMM instance implements.
+///
+/// UNICOMM is one peripheral which is a UART, an SPI, an I2C controller or an I2C target depending
+/// on `IPMODE.SELECT`, with a register map per mode at a fixed offset below the instance's own
+/// address. **No instance implements all four**, and which it implements does not follow the
+/// instance name: on MSPM0G518x `UC0` is a UART or either half of an I2C but never an SPI, `UC2` is
+/// an SPI only, and `UC3` is a UART or an SPI.
+///
+/// An instance with one mode has nothing to select and no `IPMODE` register to select it with, so
+/// writing `IPMODE` is only meaningful where more than one of these is true.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct Unicomm {
+    /// Implements the UART register map, `0x80000` below the instance address.
+    pub uart: bool,
+
+    /// Implements the I2C controller register map, `0x60000` below the instance address.
+    pub i2c_controller: bool,
+
+    /// Implements the I2C target register map, `0x40000` below the instance address.
+    pub i2c_target: bool,
+
+    /// Implements the SPI register map, `0x20000` below the instance address.
+    pub spi: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/mspm0-metapac-gen/src/metadata.rs
+++ b/mspm0-metapac-gen/src/metadata.rs
@@ -211,6 +211,22 @@ fn generate_peripheral(
         None => quote! { None },
     };
 
+    let unicomm = match peripheral.unicomm {
+        Some(unicomm) => {
+            let (uart, spi) = (unicomm.uart, unicomm.spi);
+            let (i2c_controller, i2c_target) = (unicomm.i2c_controller, unicomm.i2c_target);
+            quote! {
+                Some(Unicomm {
+                    uart: #uart,
+                    i2c_controller: #i2c_controller,
+                    i2c_target: #i2c_target,
+                    spi: #spi,
+                })
+            }
+        }
+        None => quote! { None },
+    };
+
     Some(quote! {
         Peripheral {
             name: #name,
@@ -219,6 +235,7 @@ fn generate_peripheral(
             pins: &[#(#pins),*],
             power_domain: #power_domain,
             sys_fentries: #sys_fentries,
+            unicomm: #unicomm,
         }
     })
 }

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -26,6 +26,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Uart,
     PeripheralType::Unicomm,
     PeripheralType::UnicommI2cc,
+    PeripheralType::UnicommUart,
     PeripheralType::Vref,
     PeripheralType::Wwdt,
 ];

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -14,6 +14,8 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Cpuss,
     PeripheralType::Dma,
     PeripheralType::Canfd,
+    PeripheralType::Comp,
+    PeripheralType::Crc,
     PeripheralType::FactoryRegion,
     PeripheralType::FlashCtl,
     PeripheralType::Gpio,

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -26,6 +26,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Uart,
     PeripheralType::Unicomm,
     PeripheralType::UnicommI2cc,
+    PeripheralType::UnicommSpi,
     PeripheralType::UnicommUart,
     PeripheralType::Vref,
     PeripheralType::Wwdt,

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -24,6 +24,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Tim,
     PeripheralType::Trng,
     PeripheralType::Uart,
+    PeripheralType::Vref,
     PeripheralType::Wwdt,
 ];
 

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -26,6 +26,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Uart,
     PeripheralType::Unicomm,
     PeripheralType::UnicommI2cc,
+    PeripheralType::UnicommI2ct,
     PeripheralType::UnicommSpi,
     PeripheralType::UnicommUart,
     PeripheralType::Vref,

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -28,6 +28,15 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Wwdt,
 ];
 
+/// Register block versions which do not get the module named after their peripheral type.
+///
+/// One entry per version that has to coexist with another version of the same type on one chip.
+/// TIMB is a basic timer: it has its own register block but sits alongside the general-purpose
+/// TIMA and TIMG instances, which keep `tim`.
+///
+/// Peripheral type, version, module name.
+const VARIANT_MODULES: &[(&str, &str, &str)] = &[("tim", "btimer", "timb")];
+
 pub fn generate(chip: &Chip, all_versions: &mut BTreeMap<String, BTreeSet<String>>) -> TokenStream {
     let peripheral_imports = generate_peripheral_imports(chip, all_versions);
     let peripheral_consts = generate_peripheral_consts(chip);
@@ -38,52 +47,81 @@ pub fn generate(chip: &Chip, all_versions: &mut BTreeMap<String, BTreeSet<String
     }
 }
 
+/// The register block versions this chip needs, per peripheral type.
+///
+/// A type can need more than one: TIMB is a basic timer and does not share the general-purpose
+/// block that TIMA and TIMG use, so a chip with both needs two timer blocks generated.
+fn chip_versions(chip: &Chip) -> BTreeMap<String, BTreeSet<String>> {
+    let mut versions = BTreeMap::<String, BTreeSet<String>>::new();
+
+    for peripheral in chip.peripherals.values() {
+        if !GENERATE_PERIPHERALS.contains(&peripheral.ty) {
+            continue;
+        }
+
+        if let Some(version) = &peripheral.version {
+            versions
+                .entry(peripheral.ty.to_string())
+                .or_default()
+                .insert(version.clone());
+        }
+    }
+
+    versions
+}
+
+/// Name of the module a register block is imported as.
+///
+/// The module is normally named after the peripheral type, since a chip has one register block per
+/// type. `VARIANT_MODULES` names the versions that are the exception, so that the type keeps its
+/// own module name on every chip and a chip which also has the variant just gains a second module.
+fn module_name<'a>(ty: &'a str, version: &str) -> &'a str {
+    VARIANT_MODULES
+        .iter()
+        .find(|(variant_ty, variant_version, _)| *variant_ty == ty && *variant_version == version)
+        .map(|(_, _, module)| *module)
+        .unwrap_or(ty)
+}
+
 fn generate_peripheral_imports(
     chip: &Chip,
     all_versions: &mut BTreeMap<String, BTreeSet<String>>,
 ) -> TokenStream {
-    // Sort the peripherals by type for generation.
-    let mut peripheral_types = chip.peripherals.iter().collect::<Vec<_>>();
-    peripheral_types.sort_by_key(|(a, _)| *a);
-    peripheral_types.dedup_by_key(|(_, v)| v.ty);
+    let mut modules = BTreeMap::<String, (String, String)>::new();
 
-    peripheral_types
-        .iter()
-        .map(|(name, peripheral)| generate_import(chip, name, peripheral, all_versions))
-        .collect()
-}
-
-fn generate_import(
-    _chip: &Chip,
-    _name: &str,
-    peripheral: &Peripheral,
-    all_versions: &mut BTreeMap<String, BTreeSet<String>>,
-) -> TokenStream {
-    if !GENERATE_PERIPHERALS
-        .iter()
-        .any(|ty_generate| &peripheral.ty == ty_generate)
-    {
-        return TokenStream::default();
-    }
-
-    let name = Ident::new(
-        &format!("{}", peripheral.ty).to_lowercase(),
-        Span::call_site(),
-    );
-
-    if let Some(version) = peripheral.version.clone() {
+    for (ty, versions) in chip_versions(chip) {
         all_versions
-            .entry(name.to_string())
+            .entry(ty.clone())
             .or_default()
-            .insert(version.clone());
-        let path = format!("../../peripherals/{}_{}.rs", name, version);
-        quote! {
-            #[path = #path]
-            pub mod #name;
+            .extend(versions.iter().cloned());
+
+        for version in versions {
+            let module = module_name(&ty, &version).to_owned();
+
+            if let Some((_, other)) = modules.insert(module.clone(), (ty.clone(), version.clone()))
+            {
+                // Two register blocks cannot share a module. Whichever version is the odd one out
+                // needs an entry in `VARIANT_MODULES`.
+                panic!(
+                    "{}: {ty} versions {other} and {version} both want the module {module}",
+                    chip.name
+                );
+            }
         }
-    } else {
-        TokenStream::default()
     }
+
+    modules
+        .iter()
+        .map(|(module, (ty, version))| {
+            let module = Ident::new(module, Span::call_site());
+            let path = format!("../../peripherals/{ty}_{version}.rs");
+
+            quote! {
+                #[path = #path]
+                pub mod #module;
+            }
+        })
+        .collect()
 }
 
 fn generate_peripheral_consts(chip: &Chip) -> TokenStream {
@@ -109,11 +147,13 @@ fn generate_const(peripheral: &Peripheral) -> TokenStream {
     }
 
     let address = Literal::u32_unsuffixed(address);
-    let module = Ident::new(&format!("{}", peripheral.ty), Span::call_site());
-    let ty = Ident::new(
-        &format!("{}", peripheral.ty).to_pascal_case(),
-        Span::call_site(),
-    );
+    let ty_name = peripheral.ty.to_string();
+    let module = peripheral
+        .version
+        .as_deref()
+        .map_or(ty_name.as_str(), |version| module_name(&ty_name, version));
+    let module = Ident::new(module, Span::call_site());
+    let ty = Ident::new(&ty_name.to_pascal_case(), Span::call_site());
 
     quote! {
         pub const #name: #module::#ty = unsafe { #module::#ty::from_ptr(#address as *mut _) };

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -24,6 +24,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Tim,
     PeripheralType::Trng,
     PeripheralType::Uart,
+    PeripheralType::Unicomm,
     PeripheralType::Vref,
     PeripheralType::Wwdt,
 ];

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -25,6 +25,7 @@ const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Trng,
     PeripheralType::Uart,
     PeripheralType::Unicomm,
+    PeripheralType::UnicommI2cc,
     PeripheralType::Vref,
     PeripheralType::Wwdt,
 ];

--- a/mspm0-metapac-gen/src/peripheral.rs
+++ b/mspm0-metapac-gen/src/peripheral.rs
@@ -10,6 +10,7 @@ use quote::quote;
 /// By name, then version (if any)
 const GENERATE_PERIPHERALS: &[PeripheralType] = &[
     PeripheralType::Adc,
+    PeripheralType::Beeper,
     PeripheralType::Cpuss,
     PeripheralType::Dma,
     PeripheralType::Canfd,

--- a/mspm0-metapac-gen/src/registers.rs
+++ b/mspm0-metapac-gen/src/registers.rs
@@ -31,7 +31,7 @@ pub fn generate(out_dir: &Path) -> anyhow::Result<()> {
 
     let re = Regex::new("# *! *\\[.*\\]").unwrap();
 
-    for f in glob::glob("data/registers/*").unwrap() {
+    for f in glob::glob("data/registers/*.yaml").unwrap() {
         let f = f.unwrap();
 
         if !f.is_file() {

--- a/transforms/SYSCTL_C110x.yaml
+++ b/transforms/SYSCTL_C110x.yaml
@@ -512,6 +512,18 @@ transforms:
       bit_size: 8
       enum: EXLFCTL_KEY
 
+  # EXLFCTL::SETUSEEXLF is at the wrong bit offset, so replace it
+  - !DeleteFields
+    fieldset: EXLFCTL
+    from: SETUSEEXLF
+
+  - !AddFields
+    fieldset: EXLFCTL
+    fields:
+    - name: SETUSEEXLF
+      bit_offset: 0
+      bit_size: 1
+
   # SHDNIOREL: Add key
   - !Add
     ir:
@@ -546,6 +558,18 @@ transforms:
       bit_size: 8
       enum: EXRSTPIN_KEY
 
+  # EXRSTPIN::DISABLE is at the wrong bit offset, so replace it
+  - !DeleteFields
+    fieldset: EXRSTPIN
+    from: DISABLE
+
+  - !AddFields
+    fieldset: EXRSTPIN
+    fields:
+    - name: DISABLE
+      bit_offset: 0
+      bit_size: 1
+
   # SYSSTATUSCLR: Add key
   - !Add
     ir:
@@ -562,6 +586,18 @@ transforms:
       bit_offset: 24
       bit_size: 8
       enum: SYSSTATUSCLR_KEY
+
+  # SYSSTATUSCLR::ALLECC is at the wrong bit offset, so replace it
+  - !DeleteFields
+    fieldset: SYSSTATUSCLR
+    from: ALLECC
+
+  - !AddFields
+    fieldset: SYSSTATUSCLR
+    fields:
+    - name: ALLECC
+      bit_offset: 0
+      bit_size: 1
 
   # SWDCFG: Add key
   - !Add

--- a/transforms/SYSCTL_L110x_L130x_L134x.yaml
+++ b/transforms/SYSCTL_L110x_L130x_L134x.yaml
@@ -76,15 +76,22 @@ transforms:
 
   # RSTCAUSE.ID.SYSWWDT0 should actually be called BOOTWWDT0 and have a value of 14
   # RSTCAUSE.ID.SYSWWDT1 does not exist for L-series
+  #
+  # BOOTSW is at 10 in the SVD, which SLAU847's "Reset Causes" table contradicts. See
+  # data/registers/README.md.
   - !DeleteEnumVariants
     enum: ID
-    from: (SYSWWDT0|SYSWWDT1)
+    from: (SYSWWDT0|SYSWWDT1|BOOTSW)
 
   - !AddEnumVariants
     enum: ID
     variants:
     - name: BOOTWWDT0
+      description: WWDT0 violation.
       value: 14
+    - name: BOOTSW
+      description: Software triggered BOOTRST.
+      value: 13
 
   # RESETCMD: Add KEY
   - !Add

--- a/transforms/TIM.yaml
+++ b/transforms/TIM.yaml
@@ -385,6 +385,20 @@ transforms:
     from: C0CCP(\d+)
     to: C0CCP
 
+  # Channels 4 and 5 are compare only and sit above the CCU bits rather than next to CCD0-3, so
+  # these need the offset list rather than a stride. See data/registers/README.md.
+  - !MakeFieldArray
+    fieldsets: (IMASK|RIS|MIS|ISET|ICLR)
+    from: CCD(\d+)
+    to: CCD
+    mode: Cursed
+
+  - !MakeFieldArray
+    fieldsets: (IMASK|RIS|MIS|ISET|ICLR)
+    from: CCU(\d+)
+    to: CCU
+    mode: Cursed
+
   # Ratio is useless
   - !DeleteEnums
     from: RATIO

--- a/transforms/UNICOMM_I2CC.yaml
+++ b/transforms/UNICOMM_I2CC.yaml
@@ -1,0 +1,112 @@
+# Transform for UART registers based on UC0_I2CC on G350x
+transforms:
+  - !DeleteUselessEnums
+
+  # However DeleteUselessEnums does not delete MIS and IMASK (due to CLR being 0 and SET being 1)
+  #
+  # TODO: Add this to chiptool
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLR
+      1: SET
+
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLEARED
+      1: SET
+
+  # FREE is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: STOP
+      1: RUN
+
+  # RESETASSERT is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: ASSERT
+
+  # RESETSTKY is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NORES
+      1: RESET
+
+  # RESETSTKYCLR is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: CLR
+
+  # INTEVAL is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: DISABLE
+      1: EVAL
+
+  # TODO: Something better than a cursed rename as merge
+  - !MergeBlocks
+    from: UC0_I2CC
+    main: UC0_I2CC
+    to: I2C
+
+  # Remove prefixes
+  - !RenameRegisters
+    block: .*
+    from: UC0_I2CC_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: UC0_I2CC_(.+)
+    to: $1
+
+  - !Rename
+    type: All
+    from: UC0_I2CC_(.+)
+    to: $1
+
+  ## Interrupts
+  # CPU_INT interrupt fields are all the same layout.
+  - !MergeFieldsets
+    from: CPU_INT_(IMASK|ISET|MIS|RIS|ICLR)
+    to: CPU_INT
+
+  # Remove redundant prefixes in the CPU_INT block
+  - !RenameRegisters
+    block: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  ## DMA Triggers
+  # DMA_TRIG0 and DMA_TRIG1 are not the same block here and are not merged. The standalone I2C is
+  # one peripheral for both roles, so both of its trigger blocks carry all four FIFO trigger bits;
+  # a UNICOMM instance is a controller or a target, so DMA_TRIG0 has only TXTRG and DMA_TRIG1 only
+  # RXTRG.
+  - !RenameRegisters
+    block: DMA_TRIG(\d+)
+    from: DMA_TRIG(\d+)_(.+)
+    to: $2
+
+  # Within one trigger the interrupt registers do share a layout.
+  - !MergeFieldsets
+    from: DMA_TRIG0_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG0
+
+  - !MergeFieldsets
+    from: DMA_TRIG1_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG1
+
+  ## CMODE/TMODE: same enum
+  - !MergeEnums
+    from: (C|T)MODE
+    to: MODE
+
+  ## Cleanup
+  - !Sort

--- a/transforms/UNICOMM_I2CC.yaml
+++ b/transforms/UNICOMM_I2CC.yaml
@@ -108,5 +108,13 @@ transforms:
     from: (C|T)MODE
     to: MODE
 
+
+  # ICLR has the same layout as the other CPU_INT registers. The standalone uart_v1 and i2c_v1
+  # carry one fieldset for all five, and two identical fieldsets is the bloat the README warns of.
+  - !MergeFieldsets
+    from: (CPU_INT|ICLR)
+    to: CPU_INT
+    check: NoCheck
+
   ## Cleanup
   - !Sort

--- a/transforms/UNICOMM_I2CT.yaml
+++ b/transforms/UNICOMM_I2CT.yaml
@@ -108,5 +108,13 @@ transforms:
     from: (C|T)MODE
     to: MODE
 
+
+  # ICLR has the same layout as the other CPU_INT registers. The standalone uart_v1 and i2c_v1
+  # carry one fieldset for all five, and two identical fieldsets is the bloat the README warns of.
+  - !MergeFieldsets
+    from: (CPU_INT|ICLR)
+    to: CPU_INT
+    check: NoCheck
+
   ## Cleanup
   - !Sort

--- a/transforms/UNICOMM_I2CT.yaml
+++ b/transforms/UNICOMM_I2CT.yaml
@@ -1,4 +1,4 @@
-# Transform for UART registers based on UC0_I2CC on G350x
+# Transform for UART registers based on UC0_I2CT on G350x
 transforms:
   - !DeleteUselessEnums
 
@@ -47,24 +47,24 @@ transforms:
 
   # TODO: Something better than a cursed rename as merge
   - !MergeBlocks
-    from: UC0_I2CC
-    main: UC0_I2CC
-    to: UNICOMMI2CC
+    from: UC0_I2CT
+    main: UC0_I2CT
+    to: UNICOMMI2CT
 
   # Remove prefixes
   - !RenameRegisters
     block: .*
-    from: UC0_I2CC_(.+)
+    from: UC0_I2CT_(.+)
     to: $1
 
   - !RenameFields
     fieldset: .*
-    from: UC0_I2CC_(.+)
+    from: UC0_I2CT_(.+)
     to: $1
 
   - !Rename
     type: All
-    from: UC0_I2CC_(.+)
+    from: UC0_I2CT_(.+)
     to: $1
 
   ## Interrupts

--- a/transforms/UNICOMM_SPI.yaml
+++ b/transforms/UNICOMM_SPI.yaml
@@ -130,5 +130,22 @@ transforms:
     from: DMA_TRIG_TX_(.+)
     to: $1
 
+
+  # ICLR has the same layout as the other CPU_INT registers. The standalone uart_v1 and i2c_v1
+  # carry one fieldset for all five, and two identical fieldsets is the bloat the README warns of.
+  - !MergeFieldsets
+    from: (CPU_INT|ICLR)
+    to: CPU_INT
+    check: NoCheck
+
+  ## REPEATTX names only its disabled value, and BUSY is IDLE/ACTIVE on a status bit
+  - !DeleteEnums
+    from: (REPEATTX|BUSY)
+
+  ## CTL1 and STAT describe the command/data framing with the same two values
+  - !MergeEnums
+    from: (CTL1|STAT)_CDMODE
+    to: CDMODE
+
   ## Cleanup
   - !Sort

--- a/transforms/UNICOMM_SPI.yaml
+++ b/transforms/UNICOMM_SPI.yaml
@@ -1,0 +1,134 @@
+# Transform for the UNICOMM UART register map, based on UC2_SPI on G120x, which has the
+# GFCTL glitch filter and LINCTL.EN_FRM_ERR that the G518x SVD leaves out and hw_unicommuart.h
+# confirms.
+#
+# The wrapper (GPRCM, IPMODE) is a peripheral of its own, so this map has neither, and no
+# EVT_MODE: the mode maps do not carry one.
+transforms:
+  - !DeleteUselessEnums
+
+  - !DeleteFieldsets
+    from: .*
+    useless: true
+
+  # However DeleteUselessEnums does not delete MIS and IMASK (due to CLR being 0 and SET being 1)
+  #
+  # TODO: Add this to chiptool
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLR
+      1: SET
+
+  # BUSY is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLEARED
+      1: SET
+
+  # FREE is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: STOP
+      1: RUN
+
+  # RESETASSERT is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: ASSERT
+
+  # RESETSTKY is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NORES
+      1: RESET
+
+  # RESETSTKYCLR is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: CLR
+
+  # TXD_OUT is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: LOW
+      1: HIGH
+
+  # INTEVAL is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: DISABLE
+      1: EVAL
+
+  # TODO: Something better than a cursed rename as merge
+  - !MergeBlocks
+    from: UC2_SPI
+    main: UC2_SPI
+    to: UNICOMMSPI
+
+  # Remove prefixes
+  - !RenameRegisters
+    block: .*
+    from: UC2_SPI_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: UC2_SPI_(.+)
+    to: $1
+
+  - !Rename
+    type: All
+    from: UC2_SPI_(.+)
+    to: $1
+
+  ## Interrupts
+  # The three event blocks are already named here, unlike the standalone UART's INT_EVENTn.
+  - !MergeFieldsets
+    from: CPU_INT_(IMASK|ISET|MIS|RIS|ICLR)
+    to: CPU_INT
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  - !MergeFieldsets
+    from: DMA_TRIG_RX_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG_RX
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: DMA_TRIG_RX_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: DMA_TRIG_RX_(.+)
+    to: $1
+
+  - !MergeFieldsets
+    from: DMA_TRIG_TX_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG_TX
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: DMA_TRIG_TX_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: DMA_TRIG_TX_(.+)
+    to: $1
+
+  ## Cleanup
+  - !Sort

--- a/transforms/UNICOMM_UART.yaml
+++ b/transforms/UNICOMM_UART.yaml
@@ -161,7 +161,7 @@ transforms:
     to: LINC
 
   - !MakeRegisterArray
-    blocks: UART
+    blocks: UNICOMMUART
     from: LINC(\d+)
     to: LINC
 
@@ -206,6 +206,14 @@ transforms:
   - !MergeFieldsets
     from: CLKDIV(.*)
     to: CLKDIV
+
+
+  # ICLR has the same layout as the other CPU_INT registers. The standalone uart_v1 and i2c_v1
+  # carry one fieldset for all five, and two identical fieldsets is the bloat the README warns of.
+  - !MergeFieldsets
+    from: (CPU_INT|ICLR)
+    to: CPU_INT
+    check: NoCheck
 
   ## Cleanup
   - !Sort

--- a/transforms/UNICOMM_UART.yaml
+++ b/transforms/UNICOMM_UART.yaml
@@ -1,0 +1,211 @@
+# Transform for the UNICOMM UART register map, based on UC0_UART on G120x, which has the
+# GFCTL glitch filter and LINCTL.EN_FRM_ERR that the G518x SVD leaves out and hw_unicommuart.h
+# confirms.
+#
+# The wrapper (GPRCM, IPMODE) is a peripheral of its own, so this map has neither, and no
+# EVT_MODE: the mode maps do not carry one.
+transforms:
+  - !DeleteUselessEnums
+
+  - !DeleteFieldsets
+    from: .*
+    useless: true
+
+  # However DeleteUselessEnums does not delete MIS and IMASK (due to CLR being 0 and SET being 1)
+  #
+  # TODO: Add this to chiptool
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLR
+      1: SET
+
+  # BUSY is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: CLEARED
+      1: SET
+
+  # FREE is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: STOP
+      1: RUN
+
+  # RESETASSERT is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: ASSERT
+
+  # RESETSTKY is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NORES
+      1: RESET
+
+  # RESETSTKYCLR is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: NOP
+      1: CLR
+
+  # TXD_OUT is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: LOW
+      1: HIGH
+
+  # INTEVAL is useless
+  - !DeleteEnumsWithVariants
+    variants:
+      0: DISABLE
+      1: EVAL
+
+  # TODO: Something better than a cursed rename as merge
+  - !MergeBlocks
+    from: UC0_UART
+    main: UC0_UART
+    to: UNICOMMUART
+
+  # Remove prefixes
+  - !RenameRegisters
+    block: .*
+    from: UC0_UART_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: UC0_UART_(.+)
+    to: $1
+
+  - !Rename
+    type: All
+    from: UC0_UART_(.+)
+    to: $1
+
+  ## Interrupts
+  # The three event blocks are already named here, unlike the standalone UART's INT_EVENTn.
+  - !MergeFieldsets
+    from: CPU_INT_(IMASK|ISET|MIS|RIS|ICLR)
+    to: CPU_INT
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: CPU_INT_(.+)
+    to: $1
+
+  - !MergeFieldsets
+    from: DMA_TRIG_RX_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG_RX
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: DMA_TRIG_RX_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: DMA_TRIG_RX_(.+)
+    to: $1
+
+  - !MergeFieldsets
+    from: DMA_TRIG_TX_(IMASK|ISET|MIS|RIS|ICLR)
+    to: DMA_TRIG_TX
+    check: NoCheck
+
+  - !RenameRegisters
+    block: .*
+    from: DMA_TRIG_TX_(.+)
+    to: $1
+
+  - !RenameFields
+    fieldset: .*
+    from: DMA_TRIG_TX_(.+)
+    to: $1
+
+  ## DGFSEL is an integer value, so the enum is useless
+
+  - !DeleteEnums
+    from: DGFSEL
+
+  ## EVT_MODE
+  # Merge INTx_CFG enums
+  - !MergeEnums
+    from: INT(\d+)_CFG
+    to: INT_CFG
+
+  # Rename fields to match interrupt names
+  - !RenameFields
+    fieldset: EVT_MODE
+    from: INT0_CFG
+    to: CPU
+  - !RenameFields
+    fieldset: EVT_MODE
+    from: INT1_CFG
+    to: DMA_TRIG_RX
+  - !RenameFields
+    fieldset: EVT_MODE
+    from: INT2_CFG
+    to: DMA_TRIG_TX
+
+  ## Combine LINCx fields, these are the same
+  - !MergeFieldsets
+    from: LINC(\d+)
+    to: LINC
+
+  - !MakeRegisterArray
+    blocks: UART
+    from: LINC(\d+)
+    to: LINC
+
+  ### Set RXIFLSEL and TXIFLSEL to enum to IFLSSEL 
+  - !Add
+    ir:
+      enum/IFLSSEL:
+        bit_size: 3
+        variants:
+          - name: ONE_FOURTH_ULP
+            description: RX FIFO >= 1/4 full, for ULP domain
+            value: 0
+          - name: ONE_FOURTH
+            description: RX FIFO >= 1/4 full or TX FIFO <= 1/4 full
+            value: 1
+          - name: HALF
+            description: RX FIFO >= 1/2 full or TX FIFO <= 1/2 full
+            value: 2
+          - name: THREE_FOURTH
+            description: RX FIFO >= 3/4 full or TX FIFO <= 3/4 full
+            value: 3
+          - name: FULL_ULP
+            description: RX FIFO is full, for ULP domain
+            value: 4
+          - name: FULL
+            description: RX or TX FIFO is full
+            value: 5
+          - name: AT_LEAST_ONE
+            description: RX or TX FIFO >= 1 entry available/free
+            value: 7
+
+  - !ModifyFieldsEnum
+    fieldset: IFLS
+    field: (RX|TX)IFLSEL
+    enum: IFLSSEL
+
+  ## CLKDIV[2] is same enum and fieldset
+  - !MergeEnums
+    from: CLKDIV(.*)
+    to: CLKDIV
+
+  - !MergeFieldsets
+    from: CLKDIV(.*)
+    to: CLKDIV
+
+  ## Cleanup
+  - !Sort


### PR DESCRIPTION
## The cleanup rules, applied to every block

The README's rules had been applied to some blocks and not others.

## Widths, checked against the headers

A field whose enumerated values do not fit its width suggests that the width is wrong.

- `cpuss_v1` gave the interrupt group's `MIS`, `ISET` and `ICLR` one bit where `hw_cpuss.h` masks all
  five registers `0xFF`. A caller was confined to interrupt 0.
- `gpio_v1` based both generic event blocks at bit 0, where `GEN_EVENT1` masks DIO16 to DIO31 at bits
  16 to 31.
- The UNICOMM UART and I2C maps give `CLKDIV.RATIO` three bits, as do the SVD and the TRM's
  bit-range column, while the same rows enumerate ratios to 63 and the header masks `0x3F`.

## Six blocks that did not exist

VREF, TIMB, the four UNICOMM mode maps, COMP and CRC, plus a SYSCTL for the C1105/C1106.

**TIMB was mapped to `tim_v1` and should not have been.** It is a basic timer: its `CTL0`/`LD`/`CNT`
sit at `0x1100` where the general-purpose block has `CCPD`/`ODIS`/`CCLKCTL`, and it doesn't have
`CLKDIV`/`CLKSEL` or a `COUNTERREGS` group.

Its counter array follows the TRM and TI's own header rather than the SVD, which declares four counters twelve bytes apart. SLAU846 35.4.20 and SLAU847 29.4.20 both give `1100h + (j * 100h)`, and `hw_btimer.h` declares `CTRREGS[2]` with a 256-byte stride, which is how `dl_timerb.h` indexes it.

## SYSCTL splits and corrections

**The G518x was borrowing the G350x block.** That block is missing the whole `0x3000` flash-protection region and describes a `PMUOPAMP` and a `CANCLKSRC` the part does not have. TI's per-family header and SVD agree the G518x SYSCTL is the G351x layout minus the SRAM bank-1 registers, plus the USB FLL. Derived from `sysctl_g351x_g151x` and checked against the G518X SVD.

**SLAU893 documents two C-series SYSCTLs by name** — `SYSCTL_C1103_C1104` and `SYSCTL_C1105_C1106`, the second is a strict superset: crystal drivers, `MCLKCFG.FLASHWAIT` and the HSCLK mux.
When a TRM splits a peripheral's register section per part, that suggests we should split the perimap entry.

Five fields were an enum in some SYSCTL versions and bare in others, so a single write did not compile across blocks. They now agree.

## The generated data

Every difference against `master` is one of: a peripheral gaining a `version` because its block now exists, `BEEPER` appearing on the six families whose SYSCTL has `BEEPCFG`, the UNICOMM mode peripherals, `TIMB` moving from `v1` to `btimer`, and the G518x SYSCTL moving to its own block.
Nothing is removed.

## Notes for review

The evidence for each deliberate departure from an SVD used to live in YAML comments, which `chiptool fmt` silently strips. It moves to `data/registers/README.md`. The generator's glob took every file in that directory and parsed it as IR, so it is restricted to `*.yaml` in the same commit.
This one-line change also appears in the generator-cleanup PR, where it is inert.